### PR TITLE
test: cla-bot unsigned-contributor check (will close)

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -1,5 +1,5 @@
 {
-  "contributors": ["saedx1"],
+  "contributors": [],
   "message": "Thanks for the pull request! Before this can be merged, please read and agree to the [Contributor License Agreement](https://github.com/instancez/instancez/blob/main/CLA.md), then post a comment here with:\n\n> I have read and agree to the instancez CLA (CLA.md).\n\nA maintainer will then add you to the approved contributors list. The following committers still need to sign: {{usersWithoutCLA}}",
   "label": "cla-signed",
   "recheckComment": "Rechecking CLA status now that the contributors list has been updated."

--- a/CLA.md
+++ b/CLA.md
@@ -46,3 +46,4 @@ I have read and agree to the instancez CLA (CLA.md).
 ```
 
 A maintainer will confirm this is on file before merging. You only need to do this once — subsequent contributions from the same GitHub account are covered by the same signature.
+test change


### PR DESCRIPTION
Throwaway PR to verify bot behavior when contributor is not on the approved list.