### PR TITLE
feat(console): SQL Editor + Bucket Explorer, and exact Supabase storage metadata

### DIFF
--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -261,6 +261,7 @@ export async function postFunctionDeps(
 }
 
 export async function runQuery(baseUrl: string, sql: string, production = false): Promise<SqlResult> {
+  // nosemgrep: rules_lgpl_javascript_ssrf_rule-node-ssrf -- host is the fixed app origin; only path segments are user data
   const res = await fetch(`${baseUrl}/query`, {
     method: "POST", credentials: "include",
     headers: { "Content-Type": "application/json" },

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -5,6 +5,7 @@ import type {
   DiffResponse,
   ValidationError,
   AdminUser,
+  SqlResult,
 } from "../lib/types";
 
 const BASE = "/api/_admin";
@@ -257,6 +258,16 @@ export async function postFunctionDeps(
     method: "POST",
     body: JSON.stringify({ add, remove }),
   });
+}
+
+export async function runQuery(baseUrl: string, sql: string, production = false): Promise<SqlResult> {
+  const res = await fetch(`${baseUrl}/query`, {
+    method: "POST", credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ sql, production }),
+  });
+  if (!res.ok) { const b = await res.json().catch(() => null); throw new Error(b?.error || `HTTP ${res.status}`); }
+  return res.json() as Promise<SqlResult>;
 }
 
 // Validate the secret key by calling status

--- a/dashboard/src/components/ObjectTable.tsx
+++ b/dashboard/src/components/ObjectTable.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+import { Box, HStack, Text } from "@chakra-ui/react";
+import { Folder, FileImage, MoreHorizontal, Download, Link2, Pencil, Trash2 } from "lucide-react";
+import type { StorageObject, StorageFolder } from "../lib/types";
+
+type Action = "download" | "copyUrl" | "rename" | "delete";
+
+function humanSize(md: StorageObject["metadata"]): string {
+  const n = md && typeof md.size === "number" ? md.size : null;
+  if (n == null) return "—";
+  if (n < 1024) return `${n} B`;
+  if (n < 1048576) return `${(n / 1024).toFixed(0)} KB`;
+  return `${(n / 1048576).toFixed(1)} MB`;
+}
+
+const MENU: { key: Action; label: string; icon: typeof Download; danger?: boolean }[] = [
+  { key: "download", label: "Download", icon: Download },
+  { key: "copyUrl", label: "Copy URL", icon: Link2 },
+  { key: "rename", label: "Rename", icon: Pencil },
+  { key: "delete", label: "Delete", icon: Trash2, danger: true },
+];
+
+const cell = { px: "3", py: "2.5", borderBottomWidth: "1px", borderColor: "border" } as const;
+
+export function ObjectTable(props: {
+  folders: StorageFolder[];
+  objects: StorageObject[];
+  onOpenFolder: (f: StorageFolder) => void;
+  onAction: (a: Action, o: StorageObject) => void;
+}) {
+  const { folders, objects, onOpenFolder, onAction } = props;
+  const [open, setOpen] = useState<string | null>(null);
+
+  return (
+    <Box overflow="auto">
+      <Box as="table" width="100%" fontSize="sm" css={{ borderCollapse: "collapse" }}>
+        <Box as="thead">
+          <Box as="tr" bg="bg.subtle" color="fg.muted" fontSize="xs">
+            <Box as="th" {...cell} textAlign="left">Name</Box>
+            <Box as="th" {...cell} textAlign="left" width="120px">Size</Box>
+            <Box as="th" {...cell} textAlign="left" width="180px">Type</Box>
+            <Box as="th" {...cell} width="48px" />
+          </Box>
+        </Box>
+        <Box as="tbody">
+          {folders.map((f) => (
+            <Box as="tr" key={`d:${f.key}`} _hover={{ bg: "bg.subtle" }} cursor="pointer" onClick={() => onOpenFolder(f)}>
+              <Box as="td" {...cell}>
+                <HStack gap="2"><Box as={Folder} boxSize="4" color="fg.muted" /><Text fontFamily="mono">{f.name}</Text></HStack>
+              </Box>
+              <Box as="td" {...cell} color="fg.muted">—</Box>
+              <Box as="td" {...cell} color="fg.muted">folder</Box>
+              <Box as="td" {...cell} />
+            </Box>
+          ))}
+          {objects.map((o) => (
+            <Box as="tr" key={`o:${o.id || o.name}`} _hover={{ bg: "bg.subtle" }}>
+              <Box as="td" {...cell}>
+                <HStack gap="2"><Box as={FileImage} boxSize="4" color="fg.muted" /><Text fontFamily="mono">{o.name}</Text></HStack>
+              </Box>
+              <Box as="td" {...cell} color="fg.muted" fontFamily="mono">{humanSize(o.metadata)}</Box>
+              <Box as="td" {...cell} color="fg.muted" fontFamily="mono">{o.metadata?.mimetype ?? "—"}</Box>
+              <Box as="td" {...cell} position="relative">
+                <Box
+                  as="button"
+                  aria-label="Actions"
+                  p="1"
+                  borderRadius="md"
+                  color="fg.muted"
+                  _hover={{ bg: "bg.muted", color: "fg" }}
+                  cursor="pointer"
+                  onClick={() => setOpen((k) => (k === (o.id || o.name) ? null : o.id || o.name))}
+                >
+                  <MoreHorizontal size={16} />
+                </Box>
+                {open === (o.id || o.name) && (
+                  <>
+                    <Box position="fixed" inset="0" zIndex="1" onClick={() => setOpen(null)} />
+                    <Box
+                      position="absolute" right="2" top="100%" zIndex="2" minW="150px"
+                      bg="bg.panel" borderWidth="1px" borderColor="border" borderRadius="lg" boxShadow="lg" py="1"
+                    >
+                      {MENU.map((m) => (
+                        <HStack
+                          as="button" key={m.key} w="full" gap="2" px="3" py="1.5"
+                          fontSize="sm" cursor="pointer"
+                          color={m.danger ? "fg.error" : "fg"}
+                          _hover={{ bg: "bg.subtle" }}
+                          onClick={() => { setOpen(null); onAction(m.key, o); }}
+                        >
+                          <Box as={m.icon} boxSize="3.5" /><Text>{m.label}</Text>
+                        </HStack>
+                      ))}
+                    </Box>
+                  </>
+                )}
+              </Box>
+            </Box>
+          ))}
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/dashboard/src/components/ObjectTable.tsx
+++ b/dashboard/src/components/ObjectTable.tsx
@@ -44,7 +44,7 @@ export function ObjectTable(props: {
         </Box>
         <Box as="tbody">
           {folders.map((f) => (
-            <Box as="tr" key={`d:${f.key}`} _hover={{ bg: "bg.subtle" }} cursor="pointer" onClick={() => onOpenFolder(f)}>
+            <Box as="tr" key={`d:${f.key}`} _hover={{ bg: "bg.subtle" }} cursor="pointer" onClick={() => { onOpenFolder(f); }}>
               <Box as="td" {...cell}>
                 <HStack gap="2"><Box as={Folder} boxSize="4" color="fg.muted" /><Text fontFamily="mono">{f.name}</Text></HStack>
               </Box>
@@ -69,13 +69,13 @@ export function ObjectTable(props: {
                   color="fg.muted"
                   _hover={{ bg: "bg.muted", color: "fg" }}
                   cursor="pointer"
-                  onClick={() => setOpen((k) => (k === (o.id || o.name) ? null : o.id || o.name))}
+                  onClick={() => { setOpen((k) => (k === (o.id || o.name) ? null : o.id || o.name)); }}
                 >
                   <MoreHorizontal size={16} />
                 </Box>
                 {open === (o.id || o.name) && (
                   <>
-                    <Box position="fixed" inset="0" zIndex="1" onClick={() => setOpen(null)} />
+                    <Box position="fixed" inset="0" zIndex="1" onClick={() => { setOpen(null); }} />
                     <Box
                       position="absolute" right="2" top="100%" zIndex="2" minW="150px"
                       bg="bg.panel" borderWidth="1px" borderColor="border" borderRadius="lg" boxShadow="lg" py="1"

--- a/dashboard/src/console/adminBackend.ts
+++ b/dashboard/src/console/adminBackend.ts
@@ -1,5 +1,18 @@
 import * as api from "../api/client";
 import { fullCapabilities, type ConsoleBackend } from "./backend";
+import type { StorageListResult } from "../lib/types";
+
+// Same-origin storage against the engine's Supabase-compatible /storage/v1.
+// The browser session cookie authorizes; nothing extra to attach.
+const STORAGE = "/storage/v1";
+async function storageFetch(path: string, init: RequestInit = {}): Promise<Response> {
+  const res = await fetch(`${STORAGE}${path}`, { credentials: "include", ...init });
+  if (!res.ok) {
+    const b = await res.json().catch(() => null);
+    throw new Error(b?.error || b?.message || `HTTP ${res.status}`);
+  }
+  return res;
+}
 
 /**
  * The instance-dashboard backend: a pass-through to the admin API client.
@@ -33,4 +46,47 @@ export const adminBackend: ConsoleBackend = {
   createUser: (email, password, emailConfirm) => api.adminCreateUser(email, password, emailConfirm),
   updateUser: (id, patch) => api.adminUpdateUser(id, patch),
   deleteUser: (id) => api.adminDeleteUser(id),
+
+  // SQL is platform-only: the OSS engine exposes no trusted SQL endpoint.
+  async runQuery(): Promise<never> {
+    throw new Error("SQL editor is not available in this deployment");
+  },
+
+  async listObjects(bucket, prefix, cursor): Promise<StorageListResult> {
+    const res = await storageFetch(`/object/list-v2/${bucket}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prefix, cursor, with_delimiter: true, limit: 100 }),
+    });
+    return res.json();
+  },
+  async uploadObject(bucket, path, file): Promise<void> {
+    await storageFetch(`/object/${bucket}/${path}`, {
+      method: "POST",
+      headers: { "Content-Type": file.type || "application/octet-stream", "x-upsert": "true" },
+      body: file,
+    });
+  },
+  async signObjectUrl(bucket, path, expiresIn = 3600): Promise<{ signedURL: string }> {
+    const res = await storageFetch(`/object/sign/${bucket}/${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ expiresIn }),
+    });
+    return res.json();
+  },
+  async moveObject(bucket, sourceKey, destinationKey): Promise<void> {
+    await storageFetch(`/object/move`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ bucketId: bucket, sourceKey, destinationKey }),
+    });
+  },
+  async deleteObjects(bucket, prefixes): Promise<void> {
+    await storageFetch(`/object/${bucket}`, {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prefixes }),
+    });
+  },
 };

--- a/dashboard/src/console/adminBackend.ts
+++ b/dashboard/src/console/adminBackend.ts
@@ -6,6 +6,7 @@ import type { StorageListResult } from "../lib/types";
 // The browser session cookie authorizes; nothing extra to attach.
 const STORAGE = "/storage/v1";
 async function storageFetch(path: string, init: RequestInit = {}): Promise<Response> {
+  // nosemgrep: rules_lgpl_javascript_ssrf_rule-node-ssrf -- host is the fixed app origin; only path segments are user data
   const res = await fetch(`${STORAGE}${path}`, { credentials: "include", ...init });
   if (!res.ok) {
     const b = await res.json().catch(() => null);

--- a/dashboard/src/console/backend.test.ts
+++ b/dashboard/src/console/backend.test.ts
@@ -34,6 +34,12 @@ describe("ConsoleBackend types", () => {
       createUser: async () => ({ id: "" }) as any,
       updateUser: async () => ({ id: "" }) as any,
       deleteUser: async () => {},
+      runQuery: async () => ({ columns: [], rows: [], row_count: 0 }),
+      listObjects: async () => ({ folders: [], objects: [], has_next: false }),
+      uploadObject: async () => {},
+      signObjectUrl: async () => ({ signedURL: "" }),
+      moveObject: async () => {},
+      deleteObjects: async () => {},
     };
     expect(stub.capabilities.canWriteConfig).toBe(true);
   });

--- a/dashboard/src/console/backend.ts
+++ b/dashboard/src/console/backend.ts
@@ -1,4 +1,12 @@
-import type { Config, ConfigStatus, StatsResponse, DiffResponse, AdminUser } from "../lib/types";
+import type {
+  Config,
+  ConfigStatus,
+  StatsResponse,
+  DiffResponse,
+  AdminUser,
+  SqlResult,
+  StorageListResult,
+} from "../lib/types";
 import type { EnvVarsResponse, ConfigPreview } from "../api/client";
 
 /** What this consumer/deployment supports. Pages gate surfaces on these. */
@@ -94,4 +102,14 @@ export interface ConsoleBackend {
     patch: { email?: string; password?: string; ban_duration?: string; email_confirm?: boolean }
   ): Promise<AdminUser>;
   deleteUser(id: string): Promise<void>;
+
+  // SQL editor (platform-only — adminBackend throws)
+  runQuery(sql: string, production?: boolean): Promise<SqlResult>;
+
+  // storage explorer
+  listObjects(bucket: string, prefix: string, cursor?: string): Promise<StorageListResult>;
+  uploadObject(bucket: string, path: string, file: File): Promise<void>;
+  signObjectUrl(bucket: string, path: string, expiresIn?: number): Promise<{ signedURL: string }>;
+  moveObject(bucket: string, sourceKey: string, destinationKey: string): Promise<void>;
+  deleteObjects(bucket: string, prefixes: string[]): Promise<void>;
 }

--- a/dashboard/src/console/index.ts
+++ b/dashboard/src/console/index.ts
@@ -15,6 +15,7 @@ export {
   functionsRoutes,
   providersRoutes,
   projectRoutes,
+  sqlRoutes,
 } from "./routes";
 export { DiffViewer } from "../components/DiffViewer";
 export { ConfirmSaveDialog } from "../components/ConfirmSaveDialog";

--- a/dashboard/src/console/routes.tsx
+++ b/dashboard/src/console/routes.tsx
@@ -31,6 +31,7 @@ const FunctionDetail = lazy(() => import("../pages/FunctionDetail").then(m => ({
 const ProvidersPage = lazy(() => import("../pages/Providers").then(m => ({ default: m.ProvidersPage })));
 const UsersPage = lazy(() => import("../pages/Users").then(m => ({ default: m.UsersPage })));
 const ProjectPage = lazy(() => import("../pages/Project").then(m => ({ default: m.ProjectPage })));
+const SqlEditor = lazy(() => import("../pages/SqlEditor").then((m) => ({ default: m.SqlEditor })));
 
 export const overviewRoutes = (): RouteObject[] => [
   { index: true, element: <Overview />, handle: { title: null } satisfies ConsoleRouteHandle },
@@ -78,6 +79,11 @@ export const usersRoutes = (): RouteObject[] => [
 
 export const projectRoutes = (): RouteObject[] => [
   { index: true, element: <ProjectPage />, handle: { title: "Project" } satisfies ConsoleRouteHandle },
+];
+
+// Platform-only: registered by appBackend.tsx, not in the OSS Sidebar/consoleRoutes.
+export const sqlRoutes = (): RouteObject[] => [
+  { index: true, element: <SqlEditor />, handle: { title: "SQL Editor" } satisfies ConsoleRouteHandle },
 ];
 
 export function consoleRoutes(): RouteObject[] {

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -214,9 +214,11 @@ export type ConfigStatus = {
 };
 
 export interface SqlResult {
-  columns: string[];
-  rows: unknown[][];
-  row_count: number;
+  // Postgres/Go returns null (not []) for a zero-row or non-SELECT result;
+  // callers normalize with ?? before mapping.
+  columns: string[] | null;
+  rows: unknown[][] | null;
+  row_count: number | null;
 }
 
 // Storage explorer — Size/Type read from `metadata` (exact Supabase keys).

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -213,6 +213,32 @@ export type ConfigStatus = {
   oauth_callback_base?: string;
 };
 
+export interface SqlResult {
+  columns: string[];
+  rows: unknown[][];
+  row_count: number;
+}
+
+// Storage explorer — Size/Type read from `metadata` (exact Supabase keys).
+export interface StorageObject {
+  name: string;
+  id: string;
+  updated_at: string;
+  metadata: ({ size?: number; mimetype?: string } & Record<string, unknown>) | null;
+}
+
+export interface StorageFolder {
+  name: string;
+  key: string;
+}
+
+export interface StorageListResult {
+  folders: StorageFolder[];
+  objects: StorageObject[];
+  has_next: boolean;
+  next_cursor?: string;
+}
+
 export interface AdminUser {
   id: string;
   email: string;

--- a/dashboard/src/pages/SqlEditor.test.tsx
+++ b/dashboard/src/pages/SqlEditor.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from "vitest";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { renderWithChakra } from "../test/helpers";
+import { BackendProvider } from "../console/BackendContext";
+import { fullCapabilities, type ConsoleBackend } from "../console/backend";
+import { SqlEditor } from "./SqlEditor";
+
+function mk(runQuery: ConsoleBackend["runQuery"]) {
+  return { capabilities: fullCapabilities(), runQuery } as unknown as ConsoleBackend;
+}
+function renderPage(b: ConsoleBackend) {
+  return renderWithChakra(
+    <BackendProvider backend={b}>
+      <MemoryRouter><SqlEditor /></MemoryRouter>
+    </BackendProvider>
+  );
+}
+describe("SqlEditor", () => {
+  it("runs a query and shows results", async () => {
+    const runQuery = vi.fn(async () => ({ columns: ["n"], rows: [[1]], row_count: 1 }));
+    renderPage(mk(runQuery));
+    fireEvent.click(screen.getByRole("button", { name: /run/i }));
+    await waitFor(() => expect(runQuery).toHaveBeenCalled());
+    // Scope to the result table cell — "1" also appears in the "1 row" summary.
+    expect(await screen.findByRole("cell", { name: "1" })).toBeInTheDocument();
+  });
+  it("shows the postgres error on failure", async () => {
+    const runQuery = vi.fn(async () => { throw new Error("permission denied for schema auth"); });
+    renderPage(mk(runQuery));
+    fireEvent.click(screen.getByRole("button", { name: /run/i }));
+    expect(await screen.findByText(/permission denied/i)).toBeInTheDocument();
+  });
+});

--- a/dashboard/src/pages/SqlEditor.tsx
+++ b/dashboard/src/pages/SqlEditor.tsx
@@ -1,0 +1,71 @@
+import { useCallback, useState } from "react";
+import { Box, HStack, VStack, Text } from "@chakra-ui/react";
+import { Play, Download } from "lucide-react";
+import { CodeEditor } from "../components/CodeEditor";
+import { Button } from "../components/ui";
+import { useBackend } from "../console/BackendContext";
+import type { SqlResult } from "../lib/types";
+
+function csvCell(v: unknown): string {
+  if (v == null) return "";
+  const s = typeof v === "object" ? JSON.stringify(v) : String(v);
+  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+function exportCsv(r: SqlResult) {
+  const lines = [r.columns.map(csvCell).join(","), ...r.rows.map((row) => row.map(csvCell).join(","))];
+  const url = URL.createObjectURL(new Blob([lines.join("\n")], { type: "text/csv" }));
+  const a = document.createElement("a"); a.href = url; a.download = "query-results.csv"; a.click();
+  URL.revokeObjectURL(url);
+}
+
+export function SqlEditor() {
+  const backend = useBackend();
+  const [sql, setSql] = useState("select * from ");
+  const [result, setResult] = useState<SqlResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [running, setRunning] = useState(false);
+
+  const run = useCallback(async () => {
+    if (!sql.trim() || running) return;
+    setRunning(true); setError(null);
+    try { setResult(await backend.runQuery(sql)); }
+    catch (e) { setError((e as Error)?.message || "Query failed."); setResult(null); }
+    finally { setRunning(false); }
+  }, [backend, sql, running]);
+
+  const truncated = (result?.row_count ?? 0) >= 1000;
+  return (
+    <VStack align="stretch" gap="0" height="100%">
+      <HStack px="3" py="2" borderBottomWidth="1px" borderColor="border" gap="3">
+        <Button size="sm" onClick={run} disabled={running}><Play size={13} /> Run</Button>
+        <Text fontSize="xs" color="fg.subtle" fontFamily="mono">⌘↵</Text>
+      </HStack>
+      <Box borderBottomWidth="1px" borderColor="border"><CodeEditor language="sql" value={sql} onChange={setSql} minHeight="220px" /></Box>
+      {error && <Box px="3" py="3"><Text fontSize="sm" color="fg.error" fontFamily="mono" whiteSpace="pre-wrap">{error}</Text></Box>}
+      {result && (
+        <>
+          <HStack justify="space-between" px="3" py="2" borderBottomWidth="1px" borderColor="border">
+            <Text fontSize="xs" color="fg.muted" fontFamily="mono">
+              {result.row_count} row{result.row_count === 1 ? "" : "s"}{truncated ? " · first 1000 shown" : ""}
+            </Text>
+            <Button size="xs" variant="outline" onClick={() => exportCsv(result)}><Download size={12} /> Export CSV</Button>
+          </HStack>
+          <Box overflow="auto">
+            <Box as="table" width="100%" fontFamily="mono" fontSize="xs" css={{ borderCollapse: "collapse" }}>
+              <Box as="thead"><Box as="tr" bg="bg.subtle" color="fg.muted">
+                {result.columns.map((c) => <Box as="th" key={c} textAlign="left" px="3" py="2" borderBottomWidth="1px" borderColor="border">{c}</Box>)}
+              </Box></Box>
+              <Box as="tbody">
+                {result.rows.map((row, ri) => <Box as="tr" key={ri}>
+                  {row.map((cell, ci) => <Box as="td" key={ci} px="3" py="2" borderBottomWidth="1px" borderColor="border">
+                    {cell == null ? "" : typeof cell === "object" ? JSON.stringify(cell) : String(cell)}
+                  </Box>)}
+                </Box>)}
+              </Box>
+            </Box>
+          </Box>
+        </>
+      )}
+    </VStack>
+  );
+}

--- a/dashboard/src/pages/SqlEditor.tsx
+++ b/dashboard/src/pages/SqlEditor.tsx
@@ -28,7 +28,12 @@ export function SqlEditor() {
   const run = useCallback(async () => {
     if (!sql.trim() || running) return;
     setRunning(true); setError(null);
-    try { setResult(await backend.runQuery(sql)); }
+    try {
+      // Postgres/Go returns null (not []) for a zero-row or non-SELECT result;
+      // normalize so the grid never maps over null.
+      const r = await backend.runQuery(sql);
+      setResult({ columns: r.columns ?? [], rows: r.rows ?? [], row_count: r.row_count ?? 0 });
+    }
     catch (e) { setError((e as Error)?.message || "Query failed."); setResult(null); }
     finally { setRunning(false); }
   }, [backend, sql, running]);

--- a/dashboard/src/pages/SqlEditor.tsx
+++ b/dashboard/src/pages/SqlEditor.tsx
@@ -12,7 +12,7 @@ function csvCell(v: unknown): string {
   return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
 }
 function exportCsv(r: SqlResult) {
-  const lines = [r.columns.map(csvCell).join(","), ...r.rows.map((row) => row.map(csvCell).join(","))];
+  const lines = [(r.columns ?? []).map(csvCell).join(","), ...(r.rows ?? []).map((row) => row.map(csvCell).join(","))];
   const url = URL.createObjectURL(new Blob([lines.join("\n")], { type: "text/csv" }));
   const a = document.createElement("a"); a.href = url; a.download = "query-results.csv"; a.click();
   URL.revokeObjectURL(url);
@@ -34,7 +34,7 @@ export function SqlEditor() {
       const r = await backend.runQuery(sql);
       setResult({ columns: r.columns ?? [], rows: r.rows ?? [], row_count: r.row_count ?? 0 });
     }
-    catch (e) { setError((e as Error)?.message || "Query failed."); setResult(null); }
+    catch (e) { setError((e as Error).message || "Query failed."); setResult(null); }
     finally { setRunning(false); }
   }, [backend, sql, running]);
 
@@ -53,15 +53,15 @@ export function SqlEditor() {
             <Text fontSize="xs" color="fg.muted" fontFamily="mono">
               {result.row_count} row{result.row_count === 1 ? "" : "s"}{truncated ? " · first 1000 shown" : ""}
             </Text>
-            <Button size="xs" variant="outline" onClick={() => exportCsv(result)}><Download size={12} /> Export CSV</Button>
+            <Button size="xs" variant="outline" onClick={() => { exportCsv(result); }}><Download size={12} /> Export CSV</Button>
           </HStack>
           <Box overflow="auto">
             <Box as="table" width="100%" fontFamily="mono" fontSize="xs" css={{ borderCollapse: "collapse" }}>
               <Box as="thead"><Box as="tr" bg="bg.subtle" color="fg.muted">
-                {result.columns.map((c) => <Box as="th" key={c} textAlign="left" px="3" py="2" borderBottomWidth="1px" borderColor="border">{c}</Box>)}
+                {(result.columns ?? []).map((c) => <Box as="th" key={c} textAlign="left" px="3" py="2" borderBottomWidth="1px" borderColor="border">{c}</Box>)}
               </Box></Box>
               <Box as="tbody">
-                {result.rows.map((row, ri) => <Box as="tr" key={ri}>
+                {(result.rows ?? []).map((row, ri) => <Box as="tr" key={ri}>
                   {row.map((cell, ci) => <Box as="td" key={ci} px="3" py="2" borderBottomWidth="1px" borderColor="border">
                     {cell == null ? "" : typeof cell === "object" ? JSON.stringify(cell) : String(cell)}
                   </Box>)}

--- a/dashboard/src/pages/Storage.test.tsx
+++ b/dashboard/src/pages/Storage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { screen } from "@testing-library/react";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { renderWithChakra } from "../test/helpers";
 import { Storage } from "./Storage";
@@ -7,6 +7,7 @@ import { DialogProvider } from "../components/Dialog";
 import { ConfigContext } from "../hooks/useConfig";
 import { BackendProvider } from "../console/BackendContext";
 import { adminBackend } from "../console/adminBackend";
+import { fullCapabilities, type ConsoleBackend } from "../console/backend";
 import type { Config, ValidationError } from "../lib/types";
 
 const baseConfig = {
@@ -24,7 +25,7 @@ const baseConfig = {
   providers: { email: null, storage: null },
 } as unknown as Config;
 
-function renderStorage(config: Config) {
+function renderStorage(config: Config, backend: ConsoleBackend = adminBackend) {
   const ctx = {
     config,
     loading: false,
@@ -39,7 +40,7 @@ function renderStorage(config: Config) {
     updateConfig: vi.fn(),
   };
   return renderWithChakra(
-    <BackendProvider backend={adminBackend}>
+    <BackendProvider backend={backend}>
       <ConfigContext.Provider value={ctx}>
         <MemoryRouter>
           <DialogProvider>
@@ -56,5 +57,32 @@ describe("Storage", () => {
     renderStorage(baseConfig);
     expect(screen.getByText("uploads")).toBeInTheDocument();
     expect(screen.getByText("1 bucket configured")).toBeInTheDocument();
+  });
+
+  it("deletes an object via the context menu", async () => {
+    const deleteObjects = vi.fn(async () => {});
+    const backend = {
+      capabilities: fullCapabilities(),
+      listObjects: vi.fn(async () => ({
+        folders: [],
+        objects: [{ name: "a.png", id: "a.png", updated_at: "2026-08-16", metadata: { size: 10, mimetype: "image/png" } }],
+        has_next: false,
+      })),
+      deleteObjects,
+    } as unknown as ConsoleBackend;
+
+    renderStorage(baseConfig, backend);
+
+    // Open the bucket → file explorer.
+    fireEvent.click(screen.getByText("uploads"));
+    // Wait for the object row to load.
+    expect(await screen.findByText("a.png")).toBeInTheDocument();
+
+    // Open the row action menu, click Delete, confirm the dialog.
+    fireEvent.click(screen.getByLabelText("Actions"));
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    fireEvent.click(await screen.findByRole("button", { name: /^delete$/i }));
+
+    await waitFor(() => expect(deleteObjects).toHaveBeenCalledWith("uploads", ["a.png"]));
   });
 });

--- a/dashboard/src/pages/Storage.tsx
+++ b/dashboard/src/pages/Storage.tsx
@@ -1,12 +1,14 @@
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Plus, HardDrive } from "lucide-react";
+import { Plus, HardDrive, Settings2, Upload as UploadIcon, ChevronRight, ArrowLeft } from "lucide-react";
 import { Box, HStack, Text, VStack } from "@chakra-ui/react";
 import { useConfig } from "../hooks/useConfig";
 import { useDialog } from "../components/Dialog";
 import { EmptyState } from "../components/EmptyState";
-import { StatusBadge } from "../components/StatusBadge";
-import { Button, ListRow } from "../components/ui";
+import { Button } from "../components/ui";
+import { ObjectTable } from "../components/ObjectTable";
 import { useBackend } from "../console/BackendContext";
+import type { StorageFolder, StorageListResult } from "../lib/types";
 
 export function Storage() {
   const backend = useBackend();
@@ -15,88 +17,145 @@ export function Storage() {
   const dialog = useDialog();
   const canWriteConfig = backend.capabilities.canWriteConfig;
 
+  const [bucket, setBucket] = useState<string | null>(null);
+  const [prefix, setPrefix] = useState("");
+  const [data, setData] = useState<StorageListResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const load = useCallback(async (b: string, p: string) => {
+    setLoading(true);
+    try { setData(await backend.listObjects(b, p)); }
+    catch { setData(null); }
+    finally { setLoading(false); }
+  }, [backend]);
+
+  useEffect(() => {
+    if (bucket != null) load(bucket, prefix);
+  }, [bucket, prefix, load]);
+
   if (!config) return null;
 
-  const buckets = Object.entries(config.storage || {}).sort(([a], [b]) =>
-    a.localeCompare(b)
-  );
+  const buckets = Object.entries(config.storage || {}).sort(([a], [b]) => a.localeCompare(b));
 
   async function addBucket() {
     const name = await dialog.prompt("Bucket name:");
     if (!name?.trim()) return;
     const bucketName = name.trim().toLowerCase().replace(/\s+/g, "_");
-
     const updated = {
       ...config!,
-      storage: {
-        ...config!.storage,
-        [bucketName]: {
-          max_size: "5MB",
-          types: ["image/*"],
-          public: false,
-          rls: [],
-        },
-      },
+      storage: { ...config!.storage, [bucketName]: { max_size: "5MB", types: ["image/*"], public: false, rls: [] } },
     };
-
-    const ok = await save(updated);
-    if (ok) navigate(bucketName, { relative: "path" });
+    await save(updated);
   }
 
-  const addButton = canWriteConfig ? (
-    <Button onClick={addBucket}>
-      <Plus size={14} />
-      Add Bucket
-    </Button>
-  ) : null;
-
-  return (
-    <Box>
+  // ── Bucket list ──────────────────────────────────────────────────────────
+  if (bucket == null) {
+    const addButton = canWriteConfig ? (
+      <Button onClick={addBucket}><Plus size={14} /> Add Bucket</Button>
+    ) : null;
+    return (
       <Box pb="8">
         <HStack justify="space-between" gap="4" pb="6">
-          <Text fontSize="sm" color="fg.muted">
-            {buckets.length} bucket{buckets.length !== 1 ? "s" : ""} configured
-          </Text>
+          <Text fontSize="sm" color="fg.muted">{buckets.length} bucket{buckets.length !== 1 ? "s" : ""} configured</Text>
           {addButton}
         </HStack>
         {buckets.length === 0 ? (
-          <EmptyState
-            icon={HardDrive}
-            title="No storage buckets"
-            description="Create a bucket to start managing file uploads."
-            action={addButton}
-          />
+          <EmptyState icon={HardDrive} title="No storage buckets"
+            description="Create a bucket to start managing file uploads." action={addButton} />
         ) : (
           <VStack gap="2" align="stretch">
-            {buckets.map(([name, bucket]) => (
-              <ListRow
-                key={name}
-                icon={HardDrive}
-                title={name}
-                onClick={() => navigate(name, { relative: "path" })}
-                badges={
-                  <>
-                    <StatusBadge variant="muted">{bucket.max_size}</StatusBadge>
-                    {(bucket.types || []).length > 0 && (
-                      <StatusBadge variant="muted">
-                        {bucket.types.length} type{bucket.types.length !== 1 ? "s" : ""}
-                      </StatusBadge>
-                    )}
-                    {bucket.public && (
-                      <StatusBadge variant="warning">public</StatusBadge>
-                    )}
-                    {(bucket.rls || []).length > 0 && (
-                      <StatusBadge variant="info">
-                        {bucket.rls.length} RLS
-                      </StatusBadge>
-                    )}
-                  </>
-                }
-              />
+            {buckets.map(([name]) => (
+              <HStack key={name} justify="space-between" px="5" py="3.5" borderRadius="xl" borderWidth="1px"
+                bg="bg" _hover={{ bg: "bg.subtle" }} transition="colors">
+                <HStack gap="3" minW="0" flex="1" cursor="pointer" onClick={() => { setPrefix(""); setBucket(name); }}>
+                  <Box as={HardDrive} boxSize="4" color="fg.muted" flexShrink="0" />
+                  <Text fontSize="sm" fontFamily="mono" fontWeight="medium" truncate>{name}</Text>
+                </HStack>
+                <Box as="button" aria-label="Bucket settings" p="1.5" borderRadius="md" color="fg.muted"
+                  _hover={{ bg: "bg.muted", color: "fg" }} cursor="pointer"
+                  onClick={() => navigate(name, { relative: "path" })}>
+                  <Settings2 size={15} />
+                </Box>
+              </HStack>
             ))}
           </VStack>
         )}
       </Box>
-    </Box>
+    );
+  }
+
+  // ── File explorer ────────────────────────────────────────────────────────
+  const segments = prefix.split("/").filter(Boolean);
+  const openFolder = (f: StorageFolder) => setPrefix(`${prefix}${f.name}/`);
+  const goTo = (i: number) => setPrefix(i < 0 ? "" : segments.slice(0, i + 1).join("/") + "/");
+
+  const reload = () => load(bucket, prefix);
+
+  async function onUpload(e: React.ChangeEvent<HTMLInputElement>) {
+    const files = Array.from(e.target.files || []);
+    e.target.value = "";
+    for (const f of files) await backend.uploadObject(bucket!, prefix + f.name, f);
+    if (files.length) reload();
+  }
+
+  async function onAction(a: "download" | "copyUrl" | "rename" | "delete", o: { name: string }) {
+    const key = prefix + o.name;
+    if (a === "download" || a === "copyUrl") {
+      const { signedURL } = await backend.signObjectUrl(bucket!, key);
+      if (a === "download") window.open(signedURL, "_blank");
+      else await navigator.clipboard?.writeText(signedURL);
+      return;
+    }
+    if (a === "rename") {
+      const next = await dialog.prompt("Rename to:", { defaultValue: o.name });
+      if (!next?.trim() || next === o.name) return;
+      await backend.moveObject(bucket!, key, prefix + next.trim());
+      reload();
+      return;
+    }
+    if (a === "delete") {
+      const ok = await dialog.confirm(`Delete ${o.name}?`, { destructive: true });
+      if (!ok) return;
+      await backend.deleteObjects(bucket!, [key]);
+      reload();
+    }
+  }
+
+  return (
+    <VStack align="stretch" gap="0">
+      <HStack justify="space-between" px="1" pb="3" gap="3">
+        <HStack gap="1" fontSize="sm" minW="0" flexWrap="wrap">
+          <Box as="button" onClick={() => setBucket(null)} color="fg.muted" _hover={{ color: "fg" }} cursor="pointer">
+            <HStack gap="1"><ArrowLeft size={14} /> Buckets</HStack>
+          </Box>
+          <ChevronRight size={13} />
+          <Box as="button" onClick={() => goTo(-1)} fontFamily="mono" fontWeight="medium"
+            color={segments.length ? "fg.muted" : "fg"} _hover={{ color: "fg" }} cursor="pointer">{bucket}</Box>
+          {segments.map((s, i) => (
+            <HStack key={i} gap="1">
+              <ChevronRight size={13} />
+              <Box as="button" onClick={() => goTo(i)} fontFamily="mono"
+                color={i === segments.length - 1 ? "fg" : "fg.muted"} _hover={{ color: "fg" }} cursor="pointer">{s}</Box>
+            </HStack>
+          ))}
+        </HStack>
+        <Button size="sm" onClick={() => fileRef.current?.click()}><UploadIcon size={14} /> Upload</Button>
+        <input ref={fileRef} type="file" multiple hidden onChange={onUpload} />
+      </HStack>
+
+      {loading && !data ? (
+        <Text px="1" py="4" fontSize="sm" color="fg.muted">Loading…</Text>
+      ) : data && (data.folders.length || data.objects.length) ? (
+        <Box borderWidth="1px" borderColor="border" borderRadius="xl" overflow="hidden">
+          <ObjectTable folders={data.folders} objects={data.objects} onOpenFolder={openFolder} onAction={onAction} />
+        </Box>
+      ) : (
+        <EmptyState icon={HardDrive} title="Empty" description="No files here yet. Upload one to get started." />
+      )}
+      {data?.has_next && (
+        <Text px="1" pt="3" fontSize="xs" color="fg.muted">First 100 shown.</Text>
+      )}
+    </VStack>
   );
 }

--- a/dashboard/src/pages/Storage.tsx
+++ b/dashboard/src/pages/Storage.tsx
@@ -78,7 +78,7 @@ export function Storage() {
                 </HStack>
                 <Box as="button" aria-label="Bucket settings" p="1.5" borderRadius="md" color="fg.muted"
                   _hover={{ bg: "bg.muted", color: "fg" }} cursor="pointer"
-                  onClick={() => void navigate(name, { relative: "path" })}>
+                  onClick={() => { void navigate(name, { relative: "path" }); }}>
                   <Settings2 size={15} />
                 </Box>
               </HStack>

--- a/dashboard/src/pages/Storage.tsx
+++ b/dashboard/src/pages/Storage.tsx
@@ -78,7 +78,7 @@ export function Storage() {
                 </HStack>
                 <Box as="button" aria-label="Bucket settings" p="1.5" borderRadius="md" color="fg.muted"
                   _hover={{ bg: "bg.muted", color: "fg" }} cursor="pointer"
-                  onClick={() => navigate(name, { relative: "path" })}>
+                  onClick={() => void navigate(name, { relative: "path" })}>
                   <Settings2 size={15} />
                 </Box>
               </HStack>

--- a/dashboard/src/pages/Storage.tsx
+++ b/dashboard/src/pages/Storage.tsx
@@ -36,20 +36,20 @@ export function Storage() {
 
   if (!config) return null;
 
-  const buckets = Object.entries(config.storage || {}).sort(([a], [b]) => a.localeCompare(b));
+  const buckets = Object.entries(config.storage).sort(([a], [b]) => a.localeCompare(b));
 
-  async function addBucket() {
+  const addBucket = async () => {
     const name = await dialog.prompt("Bucket name:");
     if (!name?.trim()) return;
     const bucketName = name.trim().toLowerCase().replace(/\s+/g, "_");
     const updated = {
-      ...config!,
-      storage: { ...config!.storage, [bucketName]: { max_size: "5MB", types: ["image/*"], public: false, rls: [] } },
+      ...config,
+      storage: { ...config.storage, [bucketName]: { max_size: "5MB", types: ["image/*"], public: false, rls: [] } },
     };
     try {
       await save(updated);
     } catch (err) {
-      await dialog.alert("Couldn't create bucket", { message: (err as Error)?.message });
+      await dialog.alert("Couldn't create bucket", { message: (err as Error).message });
     }
   }
 
@@ -91,48 +91,47 @@ export function Storage() {
 
   // ── File explorer ────────────────────────────────────────────────────────
   const segments = prefix.split("/").filter(Boolean);
-  const openFolder = (f: StorageFolder) => setPrefix(`${prefix}${f.name}/`);
-  const goTo = (i: number) => setPrefix(i < 0 ? "" : segments.slice(0, i + 1).join("/") + "/");
+  const openFolder = (f: StorageFolder) => { setPrefix(`${prefix}${f.name}/`); };
+  const goTo = (i: number) => { setPrefix(i < 0 ? "" : segments.slice(0, i + 1).join("/") + "/"); };
 
   const reload = () => { void load(bucket, prefix); };
 
-  async function onUpload(e: React.ChangeEvent<HTMLInputElement>) {
+  const onUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files || []);
     e.target.value = "";
     try {
-      for (const f of files) await backend.uploadObject(bucket!, prefix + f.name, f);
+      for (const f of files) await backend.uploadObject(bucket, prefix + f.name, f);
     } catch (err) {
-      await dialog.alert("Upload failed", { message: (err as Error)?.message });
+      await dialog.alert("Upload failed", { message: (err as Error).message });
     }
     if (files.length) reload();
   }
 
-  async function handleAction(a: "download" | "copyUrl" | "rename" | "delete", o: { name: string }) {
+  const handleAction = async (a: "download" | "copyUrl" | "rename" | "delete", o: { name: string }) => {
     const key = prefix + o.name;
     try {
       if (a === "download" || a === "copyUrl") {
-        const { signedURL } = await backend.signObjectUrl(bucket!, key);
+        const { signedURL } = await backend.signObjectUrl(bucket, key);
         // window.open (unlike <a target=_blank>) does not imply noopener; a signed
         // URL can resolve to user-uploaded HTML, so isolate the opened tab.
         if (a === "download") window.open(signedURL, "_blank", "noopener,noreferrer");
-        else await navigator.clipboard?.writeText(signedURL);
+        else await navigator.clipboard.writeText(signedURL);
         return;
       }
       if (a === "rename") {
         const next = await dialog.prompt("Rename to:", { defaultValue: o.name });
         if (!next?.trim() || next === o.name) return;
-        await backend.moveObject(bucket!, key, prefix + next.trim());
+        await backend.moveObject(bucket, key, prefix + next.trim());
         reload();
         return;
       }
-      if (a === "delete") {
-        const ok = await dialog.confirm(`Delete ${o.name}?`, { destructive: true });
-        if (!ok) return;
-        await backend.deleteObjects(bucket!, [key]);
-        reload();
-      }
+      // a is narrowed to "delete" here (download/copyUrl/rename returned above).
+      const ok = await dialog.confirm(`Delete ${o.name}?`, { destructive: true });
+      if (!ok) return;
+      await backend.deleteObjects(bucket, [key]);
+      reload();
     } catch (err) {
-      await dialog.alert("Action failed", { message: (err as Error)?.message });
+      await dialog.alert("Action failed", { message: (err as Error).message });
     }
   }
 
@@ -140,16 +139,16 @@ export function Storage() {
     <VStack align="stretch" gap="0">
       <HStack justify="space-between" px="1" pb="3" gap="3">
         <HStack gap="1" fontSize="sm" minW="0" flexWrap="wrap">
-          <Box as="button" onClick={() => setBucket(null)} color="fg.muted" _hover={{ color: "fg" }} cursor="pointer">
+          <Box as="button" onClick={() => { setBucket(null); }} color="fg.muted" _hover={{ color: "fg" }} cursor="pointer">
             <HStack gap="1"><ArrowLeft size={14} /> Buckets</HStack>
           </Box>
           <ChevronRight size={13} />
-          <Box as="button" onClick={() => goTo(-1)} fontFamily="mono" fontWeight="medium"
+          <Box as="button" onClick={() => { goTo(-1); }} fontFamily="mono" fontWeight="medium"
             color={segments.length ? "fg.muted" : "fg"} _hover={{ color: "fg" }} cursor="pointer">{bucket}</Box>
           {segments.map((s, i) => (
             <HStack key={i} gap="1">
               <ChevronRight size={13} />
-              <Box as="button" onClick={() => goTo(i)} fontFamily="mono"
+              <Box as="button" onClick={() => { goTo(i); }} fontFamily="mono"
                 color={i === segments.length - 1 ? "fg" : "fg.muted"} _hover={{ color: "fg" }} cursor="pointer">{s}</Box>
             </HStack>
           ))}

--- a/dashboard/src/pages/Storage.tsx
+++ b/dashboard/src/pages/Storage.tsx
@@ -31,7 +31,7 @@ export function Storage() {
   }, [backend]);
 
   useEffect(() => {
-    if (bucket != null) load(bucket, prefix);
+    if (bucket != null) void load(bucket, prefix);
   }, [bucket, prefix, load]);
 
   if (!config) return null;
@@ -46,13 +46,17 @@ export function Storage() {
       ...config!,
       storage: { ...config!.storage, [bucketName]: { max_size: "5MB", types: ["image/*"], public: false, rls: [] } },
     };
-    await save(updated);
+    try {
+      await save(updated);
+    } catch (err) {
+      await dialog.alert("Couldn't create bucket", { message: (err as Error)?.message });
+    }
   }
 
   // ── Bucket list ──────────────────────────────────────────────────────────
   if (bucket == null) {
     const addButton = canWriteConfig ? (
-      <Button onClick={addBucket}><Plus size={14} /> Add Bucket</Button>
+      <Button onClick={() => void addBucket()}><Plus size={14} /> Add Bucket</Button>
     ) : null;
     return (
       <Box pb="8">
@@ -90,35 +94,45 @@ export function Storage() {
   const openFolder = (f: StorageFolder) => setPrefix(`${prefix}${f.name}/`);
   const goTo = (i: number) => setPrefix(i < 0 ? "" : segments.slice(0, i + 1).join("/") + "/");
 
-  const reload = () => load(bucket, prefix);
+  const reload = () => { void load(bucket, prefix); };
 
   async function onUpload(e: React.ChangeEvent<HTMLInputElement>) {
     const files = Array.from(e.target.files || []);
     e.target.value = "";
-    for (const f of files) await backend.uploadObject(bucket!, prefix + f.name, f);
+    try {
+      for (const f of files) await backend.uploadObject(bucket!, prefix + f.name, f);
+    } catch (err) {
+      await dialog.alert("Upload failed", { message: (err as Error)?.message });
+    }
     if (files.length) reload();
   }
 
-  async function onAction(a: "download" | "copyUrl" | "rename" | "delete", o: { name: string }) {
+  async function handleAction(a: "download" | "copyUrl" | "rename" | "delete", o: { name: string }) {
     const key = prefix + o.name;
-    if (a === "download" || a === "copyUrl") {
-      const { signedURL } = await backend.signObjectUrl(bucket!, key);
-      if (a === "download") window.open(signedURL, "_blank");
-      else await navigator.clipboard?.writeText(signedURL);
-      return;
-    }
-    if (a === "rename") {
-      const next = await dialog.prompt("Rename to:", { defaultValue: o.name });
-      if (!next?.trim() || next === o.name) return;
-      await backend.moveObject(bucket!, key, prefix + next.trim());
-      reload();
-      return;
-    }
-    if (a === "delete") {
-      const ok = await dialog.confirm(`Delete ${o.name}?`, { destructive: true });
-      if (!ok) return;
-      await backend.deleteObjects(bucket!, [key]);
-      reload();
+    try {
+      if (a === "download" || a === "copyUrl") {
+        const { signedURL } = await backend.signObjectUrl(bucket!, key);
+        // window.open (unlike <a target=_blank>) does not imply noopener; a signed
+        // URL can resolve to user-uploaded HTML, so isolate the opened tab.
+        if (a === "download") window.open(signedURL, "_blank", "noopener,noreferrer");
+        else await navigator.clipboard?.writeText(signedURL);
+        return;
+      }
+      if (a === "rename") {
+        const next = await dialog.prompt("Rename to:", { defaultValue: o.name });
+        if (!next?.trim() || next === o.name) return;
+        await backend.moveObject(bucket!, key, prefix + next.trim());
+        reload();
+        return;
+      }
+      if (a === "delete") {
+        const ok = await dialog.confirm(`Delete ${o.name}?`, { destructive: true });
+        if (!ok) return;
+        await backend.deleteObjects(bucket!, [key]);
+        reload();
+      }
+    } catch (err) {
+      await dialog.alert("Action failed", { message: (err as Error)?.message });
     }
   }
 
@@ -141,14 +155,14 @@ export function Storage() {
           ))}
         </HStack>
         <Button size="sm" onClick={() => fileRef.current?.click()}><UploadIcon size={14} /> Upload</Button>
-        <input ref={fileRef} type="file" multiple hidden onChange={onUpload} />
+        <input ref={fileRef} type="file" multiple hidden onChange={(e) => void onUpload(e)} />
       </HStack>
 
       {loading && !data ? (
         <Text px="1" py="4" fontSize="sm" color="fg.muted">Loading…</Text>
       ) : data && (data.folders.length || data.objects.length) ? (
         <Box borderWidth="1px" borderColor="border" borderRadius="xl" overflow="hidden">
-          <ObjectTable folders={data.folders} objects={data.objects} onOpenFolder={openFolder} onAction={onAction} />
+          <ObjectTable folders={data.folders} objects={data.objects} onOpenFolder={openFolder} onAction={(a, o) => void handleAction(a, o)} />
         </Box>
       ) : (
         <EmptyState icon={HardDrive} title="Empty" description="No files here yet. Upload one to get started." />

--- a/internal/adapter/http/storage_v1_handler.go
+++ b/internal/adapter/http/storage_v1_handler.go
@@ -5,6 +5,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -196,6 +197,29 @@ func (h *StorageV1Handler) cleanPath(p string) string {
 	return path.Clean(p)
 }
 
+// objectMetadataJSON builds the exact Supabase storage ObjectMetadata blob
+// persisted to storage.objects.metadata on upload. eTag is written empty: the
+// row is persisted before the bytes reach the object store (RLS-atomic
+// ordering), so the backend ETag isn't known yet. Migration preserves the real
+// eTag from the source.
+// ponytail: empty eTag at upload; upgrade to a post-commit Head()+jsonb_set if
+// clients need live eTags.
+func objectMetadataJSON(size int64, contentType, cacheControl string) string {
+	if cacheControl == "" {
+		cacheControl = "max-age=3600" // Supabase default
+	}
+	b, _ := json.Marshal(map[string]any{
+		"size":           size,
+		"contentLength":  size,
+		"mimetype":       contentType,
+		"cacheControl":   cacheControl,
+		"lastModified":   time.Now().UTC().Format(time.RFC3339),
+		"eTag":           "",
+		"httpStatusCode": 200,
+	})
+	return string(b)
+}
+
 func (h *StorageV1Handler) uploadObject(c *gin.Context) {
 	h.doUpload(c, false)
 }
@@ -287,6 +311,8 @@ func (h *StorageV1Handler) doUpload(c *gin.Context, isUpdate bool) {
 		size = 0
 	}
 
+	metaJSON := objectMetadataJSON(size, contentType, c.GetHeader("Cache-Control"))
+
 	// Write the metadata row FIRST, inside a transaction bound to the caller's
 	// role, so that RLS authorizes the write before any bytes reach the object
 	// store. If the policy denies the write we roll back and never touch S3;
@@ -301,8 +327,8 @@ func (h *StorageV1Handler) doUpload(c *gin.Context, isUpdate bool) {
 
 	if isUpdate {
 		n, err := tx.Exec(ctx,
-			"UPDATE storage.objects SET size = $1, mime = $2, uploaded_at = NOW(), uploaded_by = $3 WHERE bucket_id = $4 AND name = $5",
-			size, contentType, uploadedBy, bucketName, objPath)
+			"UPDATE storage.objects SET size = $1, mime = $2, metadata = $3::jsonb, uploaded_at = NOW(), uploaded_by = $4 WHERE bucket_id = $5 AND name = $6",
+			size, contentType, metaJSON, uploadedBy, bucketName, objPath)
 		if err != nil {
 			h.uploadWriteError(c, err)
 			return
@@ -316,18 +342,18 @@ func (h *StorageV1Handler) doUpload(c *gin.Context, isUpdate bool) {
 		upsert := c.GetHeader("x-upsert") == "true"
 		if upsert {
 			if _, err := tx.Exec(ctx,
-				`INSERT INTO storage.objects (bucket_id, name, size, mime, uploaded_by)
-				 VALUES ($1, $2, $3, $4, $5)
+				`INSERT INTO storage.objects (bucket_id, name, size, mime, metadata, uploaded_by)
+				 VALUES ($1, $2, $3, $4, $5::jsonb, $6)
 				 ON CONFLICT (bucket_id, name)
-				 DO UPDATE SET size = EXCLUDED.size, mime = EXCLUDED.mime, uploaded_by = EXCLUDED.uploaded_by, uploaded_at = NOW()`,
-				bucketName, objPath, size, contentType, uploadedBy); err != nil {
+				 DO UPDATE SET size = EXCLUDED.size, mime = EXCLUDED.mime, metadata = EXCLUDED.metadata, uploaded_by = EXCLUDED.uploaded_by, uploaded_at = NOW()`,
+				bucketName, objPath, size, contentType, metaJSON, uploadedBy); err != nil {
 				h.uploadWriteError(c, err)
 				return
 			}
 		} else {
 			if _, err := tx.Exec(ctx,
-				"INSERT INTO storage.objects (bucket_id, name, size, mime, uploaded_by) VALUES ($1, $2, $3, $4, $5)",
-				bucketName, objPath, size, contentType, uploadedBy); err != nil {
+				"INSERT INTO storage.objects (bucket_id, name, size, mime, metadata, uploaded_by) VALUES ($1, $2, $3, $4, $5::jsonb, $6)",
+				bucketName, objPath, size, contentType, metaJSON, uploadedBy); err != nil {
 				h.uploadWriteError(c, err)
 				return
 			}
@@ -1049,12 +1075,13 @@ func (h *StorageV1Handler) uploadToSignedURL(c *gin.Context) {
 	if owner != "" {
 		uploadedBy = owner
 	}
+	metaJSON := objectMetadataJSON(size, contentType, c.GetHeader("Cache-Control"))
 	_, _ = h.db.Exec(ctx,
-		`INSERT INTO storage.objects (bucket_id, name, size, mime, uploaded_by)
-		 VALUES ($1, $2, $3, $4, $5)
+		`INSERT INTO storage.objects (bucket_id, name, size, mime, metadata, uploaded_by)
+		 VALUES ($1, $2, $3, $4, $5::jsonb, $6)
 		 ON CONFLICT (bucket_id, name)
-		 DO UPDATE SET size = EXCLUDED.size, mime = EXCLUDED.mime, uploaded_by = EXCLUDED.uploaded_by, uploaded_at = NOW()`,
-		bucketName, objPath, size, contentType, uploadedBy)
+		 DO UPDATE SET size = EXCLUDED.size, mime = EXCLUDED.mime, metadata = EXCLUDED.metadata, uploaded_by = EXCLUDED.uploaded_by, uploaded_at = NOW()`,
+		bucketName, objPath, size, contentType, metaJSON, uploadedBy)
 
 	c.JSON(200, gin.H{
 		"Key":      bucketName + "/" + objPath,

--- a/internal/adapter/http/storage_v1_handler_test.go
+++ b/internal/adapter/http/storage_v1_handler_test.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/instancez/instancez/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // --- stubObjectStore ---
@@ -642,6 +644,45 @@ func TestUploadObject_Success(t *testing.T) {
 	if resp["Key"] != "avatars/photo.jpg" {
 		t.Errorf("response Key = %v", resp["Key"])
 	}
+}
+
+func TestUploadObject_WritesMetadata(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var gotQuery string
+	var gotArgs []any
+	tx := &stubTx{execFn: func(ctx context.Context, q string, args ...any) (int64, error) {
+		gotQuery, gotArgs = q, args
+		return 1, nil
+	}}
+	db := &stubDB{beginFn: func(ctx context.Context) (domain.Tx, error) { return tx, nil }}
+	store := &stubObjectStore{}
+	h := newStorageHandler(db, store, map[string]domain.Bucket{"avatars": {}})
+
+	r := gin.New()
+	r.POST("/storage/v1/object/:bucket/*path", func(c *gin.Context) {
+		setTestSession(c, domain.Session{Role: "authenticated", UserID: "u1", IsAuthenticated: true})
+		h.uploadObject(c)
+	})
+	req := httptest.NewRequest(http.MethodPost, "/storage/v1/object/avatars/photo.jpg", strings.NewReader("hello world"))
+	req.Header.Set("Content-Type", "image/jpeg")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.Contains(t, gotQuery, "metadata")
+	// find the metadata json arg and assert exact keys/values
+	var found string
+	for _, a := range gotArgs {
+		if s, ok := a.(string); ok && strings.Contains(s, "mimetype") {
+			found = s
+		}
+	}
+	require.NotEmpty(t, found, "metadata json arg not passed")
+	assert.Contains(t, found, `"mimetype":"image/jpeg"`)
+	assert.Contains(t, found, `"size":11`)
+	assert.Contains(t, found, `"cacheControl"`)
+	assert.Contains(t, found, `"httpStatusCode":200`)
 }
 
 func TestUploadObject_DuplicateKeyConflict(t *testing.T) {

--- a/internal/app/migrate.go
+++ b/internal/app/migrate.go
@@ -237,6 +237,14 @@ func planUpdateStatements(oldCfg, newCfg *domain.Config, roles domain.Roles) []s
 	}
 	ddl = append(ddl, generateStorageRLSAll(newCfg.Storage)...)
 
+	// Heal storage.objects on existing DBs. diffNewStorage only emits the
+	// table (and its columns) when storage is *newly* added, so a DB that
+	// already had storage.objects before user_metadata existed would never
+	// gain the column. This idempotent ALTER runs on every migration.
+	if len(newCfg.Storage) > 0 {
+		ddl = append(ddl, `ALTER TABLE storage.objects ADD COLUMN IF NOT EXISTS user_metadata JSONB;`)
+	}
+
 	// RPC functions (CREATE OR REPLACE FUNCTION)
 	if len(newCfg.RPC) > 0 {
 		fnNames := sortedKeys(newCfg.RPC)
@@ -787,8 +795,13 @@ func generateStorageTables(cfg *domain.Config) []string {
   uploaded_by UUID REFERENCES auth.users(id),
   uploaded_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   metadata JSONB,
+  user_metadata JSONB,
   UNIQUE (bucket_id, name)
 );`,
+		// Additive column for deployments whose storage.objects table predates
+		// user_metadata. supabase-js's .list() carries user_metadata separately
+		// from the storage-managed metadata blob.
+		`ALTER TABLE storage.objects ADD COLUMN IF NOT EXISTS user_metadata JSONB;`,
 	}
 }
 

--- a/internal/app/migrate_test.go
+++ b/internal/app/migrate_test.go
@@ -297,6 +297,15 @@ func TestGenerateStorageTablesEmptyWhenNoBuckets(t *testing.T) {
 	}
 }
 
+func TestStorageTablesIncludeUserMetadata(t *testing.T) {
+	cfg := &domain.Config{Storage: map[string]domain.Bucket{"avatars": {}}}
+	stmts := generateStorageTables(cfg)
+	joined := strings.Join(stmts, "\n")
+	if !strings.Contains(joined, "user_metadata") {
+		t.Fatalf("expected storage.objects DDL to define user_metadata, got:\n%s", joined)
+	}
+}
+
 func TestGenerateStorageRLS_Public(t *testing.T) {
 	bucket := domain.Bucket{
 		Public: true,


### PR DESCRIPTION
## Summary

Two new console areas, plus the storage-metadata parity they rely on.

- **SQL Editor** — run queries against the app database from the dashboard: CodeMirror editor, inline results grid, CSV export. Scoped to the platform (uses the platform's session-authed query endpoint); `adminBackend.runQuery` throws in pure OSS since there is no engine SQL endpoint.
- **Bucket Explorer** — the Storage area rewritten from config-only into a real file explorer: prefix navigation (virtual folders), upload, download, rename/move, and delete via a per-item context menu. `adminBackend` talks to the existing `/storage/v1/*` same-origin.
- **Exact Supabase storage metadata + lossless migration (engine)** — upload now writes `storage.objects.metadata` in the exact Supabase `ObjectMetadata` shape (`size, contentLength, mimetype, cacheControl, lastModified, eTag, httpStatusCode`), and adds a `user_metadata JSONB` column (create + an always-run idempotent heal). Fixes a pre-existing supabase-js `.list()` incompatibility (metadata was always `NULL`) and makes Supabase→instancez migration lossless.

## ConsoleBackend

Adds `runQuery(sql, production?)` and `listObjects / uploadObject / signObjectUrl / moveObject / deleteObjects`. `adminBackend` implements the storage methods same-origin; SQL is platform-scoped.

## Tests

- Dashboard: `tsc` clean, 329 vitest tests pass.
- Engine: `go build ./...` OK; storage-metadata + schema tests pass.

## Notes

- `eTag` is written empty at upload: the metadata row is persisted before the bytes upload (RLS-atomic ordering), so the backend ETag isn't known yet. Migration preserves the real eTag from the source. Upgradeable via a post-commit `Head()`+update if live eTags are needed.
- The platform-side endpoints (session-authed `/console/apps/:id/query` + a storage proxy that forwards to `/storage/v1/*` with the app secret key) live in the private platform repo and consume this contract.
