### PR TITLE
feat: auth and refresh tokens always-on

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ providers:
 
 auth:
   jwt_expiry: 15m
-  refresh_tokens: true
   refresh_token_expiry: 7d
   email:
     verify_email: false

--- a/dashboard/e2e/fixtures/instancez.yaml
+++ b/dashboard/e2e/fixtures/instancez.yaml
@@ -13,7 +13,6 @@ providers:
         type: local
 auth:
     jwt_expiry: 15m
-    refresh_tokens: true
 tables:
     notes:
         fields:

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -72,7 +72,6 @@ export interface Providers {
 
 export interface Auth {
   jwt_expiry: string;
-  refresh_tokens: boolean;
   refresh_token_expiry: string;
   // null means "unset" (the server defaults both to allowed). The dashboard
   // writes an explicit boolean once the toggle is touched.

--- a/dashboard/src/pages/Auth.test.tsx
+++ b/dashboard/src/pages/Auth.test.tsx
@@ -25,7 +25,6 @@ const makeConfig = (authEnabled: boolean): Config => ({
   auth: authEnabled
     ? {
         jwt_expiry: "15m",
-        refresh_tokens: true,
         refresh_token_expiry: "7d",
         allow_signup: null,
         allow_anonymous: null,

--- a/dashboard/src/pages/Auth.tsx
+++ b/dashboard/src/pages/Auth.tsx
@@ -121,7 +121,6 @@ If you didn't request a reset, you can safely ignore this email — your passwor
 
 const DEFAULT_AUTH: Auth = {
   jwt_expiry: "15m",
-  refresh_tokens: true,
   refresh_token_expiry: "7d",
   allow_signup: null,
   allow_anonymous: null,
@@ -333,11 +332,6 @@ export function AuthPage() {
                   />
                 </Field>
               </Grid>
-              <Toggle
-                checked={auth.refresh_tokens}
-                onChange={(v) => updateAuth((a) => ({ ...a, refresh_tokens: v }))}
-                label="Enable refresh tokens"
-              />
             </Section>
 
             <Section title="Sign-up & verification" icon={UserPlus}>

--- a/dashboard/src/pages/Overview.test.tsx
+++ b/dashboard/src/pages/Overview.test.tsx
@@ -30,7 +30,7 @@ const baseConfig: Config = {
       rls: [],
     },
   },
-  auth: { jwt_expiry: "15m", refresh_tokens: true, refresh_token_expiry: "7d", allow_signup: null, allow_anonymous: null, redirect_urls: [], email: { verify_email: false, templates: {} }, oauth: {} },
+  auth: { jwt_expiry: "15m", refresh_token_expiry: "7d", allow_signup: null, allow_anonymous: null, redirect_urls: [], email: { verify_email: false, templates: {} }, oauth: {} },
   storage: {
     avatars: { max_size: "5MB", types: ["image/*"], public: true, rls: [] },
   },

--- a/docs/examples/gearstore/instancez.yaml
+++ b/docs/examples/gearstore/instancez.yaml
@@ -18,7 +18,6 @@ auth:
     # Email + password auth. VerifyEmail is off so signup returns a session
     # immediately; no email provider is required in that mode.
     jwt_expiry: 1h
-    refresh_tokens: true
     refresh_token_expiry: 7d
     # allow_signup: false       # admin-only: POST /auth/v1/signup → 403 signup_disabled
     # allow_anonymous: false    # block empty-body anonymous sign-in

--- a/docs/site/src/assets/demo.tape
+++ b/docs/site/src/assets/demo.tape
@@ -36,7 +36,7 @@ Env BAT_STYLE "numbers"
 
 Hide
   Type@1ms `tmux -f /dev/null -L demo kill-server 2>/dev/null; rm -rf /tmp/vhsdemo && mkdir -p /tmp/vhsdemo && cd /tmp/vhsdemo` Enter
-  Type@1ms `printf 'version: 1\n\nproject:\n  name: demo\n\nproviders:\n  storage:\n    type: local\n\nauth:\n  jwt_expiry: 15m\n  refresh_tokens: true\n  allow_anonymous: true\n\ntables:\n  todos:\n    fields:\n      - name: id\n        type: bigserial\n        primary_key: true\n      - name: user_id\n        foreign_key:\n          references: auth.users.id\n          on_delete: cascade\n      - name: title\n        type: text\n        required: true\n      - name: status\n        type: text\n        enum: [pending, active, done]\n        default: pending\n    rls:\n      - operations: [select, insert, update, delete]\n        using: "user_id = auth.uid()"\n        with_check: "user_id = auth.uid()"\n' > instancez.yaml` Enter
+  Type@1ms `printf 'version: 1\n\nproject:\n  name: demo\n\nproviders:\n  storage:\n    type: local\n\nauth:\n  jwt_expiry: 15m\n  allow_anonymous: true\n\ntables:\n  todos:\n    fields:\n      - name: id\n        type: bigserial\n        primary_key: true\n      - name: user_id\n        foreign_key:\n          references: auth.users.id\n          on_delete: cascade\n      - name: title\n        type: text\n        required: true\n      - name: status\n        type: text\n        enum: [pending, active, done]\n        default: pending\n    rls:\n      - operations: [select, insert, update, delete]\n        using: "user_id = auth.uid()"\n        with_check: "user_id = auth.uid()"\n' > instancez.yaml` Enter
   Type "clear" Enter
   Type "tmux -f /dev/null -L demo new-session -- bash --norc" Enter
   Type "tmux split-window -d -h -- bash --norc" Enter

--- a/docs/site/src/content/docs/api-reference/config.md
+++ b/docs/site/src/content/docs/api-reference/config.md
@@ -83,16 +83,17 @@ Set `providers.email: null` to disable email sending.
 
 ## auth
 
-Omit the `auth:` block entirely to disable authentication endpoints.
+Auth is always provisioned, even if `auth:` is omitted entirely; the block only overrides defaults.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `auth.jwt_expiry` | `duration` | `15m` (when `auth:` is present) | Access token lifetime. Default applies only when `auth:` block is declared but `jwt_expiry` is not. |
-| `auth.refresh_tokens` | `boolean` | `false` | Enable refresh token issuance. |
-| `auth.refresh_token_expiry` | `duration` | `7d` | Refresh token lifetime (only used when `refresh_tokens: true`). |
+| `auth.jwt_expiry` | `duration` | `15m` | Access token lifetime. |
+| `auth.refresh_token_expiry` | `duration` | `7d` | Refresh token lifetime. Refresh tokens are always issued. |
 | `auth.allow_signup` | `boolean` | `true` | Allow public `POST /auth/v1/signup`. Set to `false` for invite-only. |
 | `auth.allow_anonymous` | `boolean` | `true` | Allow anonymous sign-in (empty-body signup). |
 | `auth.redirect_urls` | `string[]` | `[]` | Allowlist of origins for post-auth redirects (OAuth, email verification). The server's own origin is always allowed. |
+
+`auth.refresh_tokens` is deprecated and ignored — refresh tokens are always issued.
 
 ### auth.email
 
@@ -312,7 +313,6 @@ providers:
 
 auth:
   jwt_expiry: 1h
-  refresh_tokens: true
   refresh_token_expiry: 30d
   allow_signup: true
   allow_anonymous: false

--- a/docs/site/src/content/docs/build/auth.md
+++ b/docs/site/src/content/docs/build/auth.md
@@ -5,12 +5,11 @@ description: Password, magic link, OTP, OAuth, anonymous sign-in, and TOTP MFA â
 
 ## Configuration
 
-The `auth:` block in `instancez.yaml` controls JWT lifetime, refresh tokens, sign-up permissions, and OAuth providers:
+The `auth:` block in `instancez.yaml` controls JWT lifetime, sign-up permissions, and OAuth providers:
 
 ```yaml
 auth:
   jwt_expiry: 1h
-  refresh_tokens: true
   refresh_token_expiry: 7d
 
   # Set to false to disable public sign-up (the secret key can still create users)
@@ -43,9 +42,7 @@ auth:
       redirect_url: https://api.myapp.example.com/auth/v1/callback/github
 ```
 
-All keys are optional. Omit `auth:` entirely and JWT auth still works with the defaults (15m expiry, no refresh tokens, sign-up open).
-
-**With `refresh_tokens` off, `supabase-js` reports `session: null` even on success.** The `/auth/v1/signup` and `/auth/v1/token` responses still carry a valid `access_token`, but `supabase-js`'s client-side check for "is there a session" requires `access_token`, `refresh_token`, and `expires_in` all to be present. No `refresh_token` means `data.session` comes back `null` from `signUp()` / `signInWithPassword()`, even though the token itself works. Set `refresh_tokens: true` if you want the SDK to actually see a session.
+All keys are optional. Auth is always provisioned, even if `auth:` is omitted entirely â€” JWT auth works with the defaults (15m expiry, 7d refresh token expiry, sign-up open). Refresh tokens are always issued; the old `auth.refresh_tokens` toggle is deprecated and ignored.
 
 The dashboard's **Auth** page edits these too: the Registration toggles map to `allow_signup` / `allow_anonymous`, and the Redirect URLs list maps to `redirect_urls`. When sign-up is off, the anonymous toggle is disabled, since anonymous sign-in is blocked along with it.
 

--- a/docs/site/src/content/docs/examples/ecommerce-store.md
+++ b/docs/site/src/content/docs/examples/ecommerce-store.md
@@ -23,7 +23,6 @@ project:
 
 auth:
   jwt_expiry: 1h
-  refresh_tokens: true
   allow_signup: true
 
 tables:

--- a/docs/site/src/content/docs/examples/file-gallery.md
+++ b/docs/site/src/content/docs/examples/file-gallery.md
@@ -17,7 +17,6 @@ version: 1
 
 auth:
   jwt_expiry: 1h
-  refresh_tokens: true
   allow_signup: true
 
 providers:

--- a/instancez.yaml
+++ b/instancez.yaml
@@ -25,7 +25,6 @@ providers:
         type: local
 auth:
     jwt_expiry: 15m
-    refresh_tokens: true
     refresh_token_expiry: 7d
     # allow_signup: false       # admin-only: POST /auth/v1/signup → 403 signup_disabled
     # allow_anonymous: false    # block empty-body anonymous sign-in

--- a/internal/adapter/funcs/clients_integration_test.go
+++ b/internal/adapter/funcs/clients_integration_test.go
@@ -87,9 +87,8 @@ func TestInjectedClientsRLSAndEscalation(t *testing.T) {
 		Project: domain.Project{Name: "funcs-rls"},
 		Server:  domain.Server{Port: 0},
 		Auth: &domain.Auth{
-			JWTExpiry:     "1h",
-			RefreshTokens: false,
-			Email:         &domain.AuthEmail{VerifyEmail: false},
+			JWTExpiry: "1h",
+			Email:     &domain.AuthEmail{VerifyEmail: false},
 		},
 		Tables: map[string]domain.Table{
 			"rls_secrets": {
@@ -194,8 +193,8 @@ func TestInjectedClientsRLSAndEscalation(t *testing.T) {
 	loopback := "http://" + ln.Addr().String()
 
 	rt, err := funcs.New(funcs.Options{
-		Dir:         fnDir,
-		Functions:   map[string]domain.CodeFunction{"rls": {Runtime: "node", File: "rls.js"}},
+		Dir:            fnDir,
+		Functions:      map[string]domain.CodeFunction{"rls": {Runtime: "node", File: "rls.js"}},
 		LoopbackURL:    loopback,
 		PublishableKey: publishableKey,
 		SecretKey:      secretKey,

--- a/internal/adapter/http/auth_alwayson_routing_test.go
+++ b/internal/adapter/http/auth_alwayson_routing_test.go
@@ -1,0 +1,47 @@
+package http
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/instancez/instancez/internal/config"
+	"github.com/instancez/instancez/internal/domain"
+)
+
+// TestNewServer_AuthMountedWithoutAuthBlock proves the loader chokepoint
+// (config.ParseBytes -> applyDefaults) feeds NewServer's Config.Auth != nil
+// guard: a config with no auth: block must still mount /auth/v1/*.
+func TestNewServer_AuthMountedWithoutAuthBlock(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	yaml := []byte("version: 1\nproject:\n  name: \"test\"\ntables: {}\n")
+	cfg, err := config.ParseBytes(yaml, "test.yaml")
+	if err != nil {
+		t.Fatalf("ParseBytes: %v", err)
+	}
+	if cfg.Auth == nil {
+		t.Fatal("loader must always populate Auth (always-on)")
+	}
+
+	deps := ServerDeps{
+		Config:        cfg,
+		DB:            domain.RequestDB{Database: &stubDB{}},
+		Logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		DashboardMode: DashboardDisabled,
+	}
+	handler := NewServer(deps).Handler()
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/v1/signup", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code == http.StatusNotFound {
+		t.Fatalf("POST /auth/v1/signup: got 404 — /auth/v1 not mounted for an auth-less config")
+	}
+}

--- a/internal/adapter/http/auth_handler.go
+++ b/internal/adapter/http/auth_handler.go
@@ -358,10 +358,6 @@ func (h *AuthHandler) handlePasswordGrant(c *gin.Context) {
 }
 
 func (h *AuthHandler) handleRefreshGrant(c *gin.Context) {
-	if !h.cfg.Auth.RefreshTokens {
-		problemJSON(c, 400, "bad_request", "Refresh tokens are disabled")
-		return
-	}
 	var req struct {
 		RefreshToken string `json:"refresh_token" binding:"required"`
 	}
@@ -561,7 +557,7 @@ func (h *AuthHandler) handleLogout(c *gin.Context) {
 	scope := c.DefaultQuery("scope", "global")
 
 	ctx := c.Request.Context()
-	if h.cfg.Auth.RefreshTokens && session.UserID != "" {
+	if session.UserID != "" {
 		sessionID := h.extractSessionID(session.JWT)
 		switch scope {
 		case "local":
@@ -1487,20 +1483,18 @@ func (h *AuthHandler) buildSession(ctx context.Context, userID string, userRow m
 		"user":         h.buildUser(userID, userRow, h.userIdentities(ctx, userID)),
 	}
 
-	if h.cfg.Auth.RefreshTokens {
-		refreshToken := generateRandomToken()
-		refreshExpiry, _ := time.ParseDuration(h.cfg.Auth.RefreshTokenExpiry)
-		if refreshExpiry == 0 {
-			refreshExpiry = 7 * 24 * time.Hour
-		}
-		ip, _ := ctx.Value(ctxKeyIP).(string)
-		ua, _ := ctx.Value(ctxKeyUA).(string)
-		meta := domain.SessionMeta{SessionID: sessionID, IP: ip, UserAgent: ua}
-		if err := h.authSvc.InsertRefreshToken(context.Background(), userID, refreshToken, meta, time.Now().Add(refreshExpiry).Unix()); err != nil {
-			return nil, err
-		}
-		result["refresh_token"] = refreshToken
+	refreshToken := generateRandomToken()
+	refreshExpiry, _ := time.ParseDuration(h.cfg.Auth.RefreshTokenExpiry)
+	if refreshExpiry == 0 {
+		refreshExpiry = 7 * 24 * time.Hour
 	}
+	ip, _ := ctx.Value(ctxKeyIP).(string)
+	ua, _ := ctx.Value(ctxKeyUA).(string)
+	meta := domain.SessionMeta{SessionID: sessionID, IP: ip, UserAgent: ua}
+	if err := h.authSvc.InsertRefreshToken(context.Background(), userID, refreshToken, meta, time.Now().Add(refreshExpiry).Unix()); err != nil {
+		return nil, err
+	}
+	result["refresh_token"] = refreshToken
 
 	return result, nil
 }

--- a/internal/adapter/http/auth_handler_test.go
+++ b/internal/adapter/http/auth_handler_test.go
@@ -442,8 +442,7 @@ func TestAuthHandler_Mount_RegistersGoTrueRoutes(t *testing.T) {
 	h := &AuthHandler{
 		cfg: &domain.Config{
 			Auth: &domain.Auth{
-				RefreshTokens: true,
-				Email:         &domain.AuthEmail{VerifyEmail: true},
+				Email: &domain.AuthEmail{VerifyEmail: true},
 			},
 		},
 		jwtKeys: stubKeys(t),

--- a/internal/adapter/http/auth_handler_test.go
+++ b/internal/adapter/http/auth_handler_test.go
@@ -566,6 +566,62 @@ func TestHandleToken_UnknownGrantType(t *testing.T) {
 	}
 }
 
+// TestHandleRefreshGrant_IgnoresDeprecatedRefreshTokensFalse pins refresh
+// tokens as always-on: the deprecated auth.refresh_tokens:false toggle must
+// not resurrect the removed "disabled" 400 — a refresh grant still succeeds
+// and issues a new refresh_token.
+func TestHandleRefreshGrant_IgnoresDeprecatedRefreshTokensFalse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	inserted := false
+	svc := &stubAuthService{
+		consumeRefreshFn: func(ctx context.Context, token string) (map[string]any, error) {
+			return map[string]any{
+				"id":                 "11111111-2222-3333-4444-555555555555",
+				"email":              "u@e.com",
+				"email_verified":     true,
+				"raw_app_meta_data":  `{}`,
+				"raw_user_meta_data": `{}`,
+				"created_at":         time.Now(),
+				"updated_at":         time.Now(),
+			}, nil
+		},
+		insertRefreshTokenFn: func(ctx context.Context, userID, token string, meta domain.SessionMeta, expiresAt int64) error {
+			inserted = true
+			return nil
+		},
+	}
+	h := &AuthHandler{
+		cfg: &domain.Config{Auth: &domain.Auth{
+			JWTExpiry:     "15m",
+			RefreshTokens: ptrBool(false), // deprecated toggle; must be ignored
+		}},
+		authSvc: svc,
+		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		jwtKeys: stubKeys(t),
+	}
+	r := gin.New()
+	r.POST("/auth/v1/token", h.handleToken)
+
+	req := httptest.NewRequest("POST", "/auth/v1/token?grant_type=refresh_token",
+		strings.NewReader(`{"refresh_token":"old-token"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200 (refresh must succeed regardless of deprecated toggle), got %d: %s", w.Code, w.Body.String())
+	}
+	var body map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &body)
+	rt, _ := body["refresh_token"].(string)
+	if rt == "" {
+		t.Errorf("expected non-empty refresh_token in response, got %v", body["refresh_token"])
+	}
+	if !inserted {
+		t.Error("expected InsertRefreshToken to be called")
+	}
+}
+
 // ---------- CORS allows supabase-js headers ----------
 
 func TestCORS_AllowsSupabaseJSHeaders(t *testing.T) {

--- a/internal/adapter/http/mfa_handler_test.go
+++ b/internal/adapter/http/mfa_handler_test.go
@@ -37,9 +37,8 @@ func newMFAHarness(t *testing.T, svc *stubAuthService) *mfaHarness {
 	km := stubKeys(t)
 	h := &AuthHandler{
 		cfg: &domain.Config{Auth: &domain.Auth{
-			JWTExpiry:     "1h",
-			RefreshTokens: false,
-			Email:         &domain.AuthEmail{},
+			JWTExpiry: "1h",
+			Email:     &domain.AuthEmail{},
 		}},
 		authSvc: svc,
 		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),

--- a/internal/adapter/http/supabase_integration_test.go
+++ b/internal/adapter/http/supabase_integration_test.go
@@ -146,8 +146,7 @@ func TestSupabaseJSCompat(t *testing.T) {
 		Project: domain.Project{Name: "integration"},
 		Server:  domain.Server{Port: 0},
 		Auth: &domain.Auth{
-			JWTExpiry:     "1h",
-			RefreshTokens: true,
+			JWTExpiry: "1h",
 			// The recovery/verify flow redirects to the app; the allowlist must
 			// include it or the redirect (which carries the session tokens)
 			// falls back to the base URL. See the redirect-allowlist hardening.
@@ -770,4 +769,3 @@ func runPasswordResetFlow(t *testing.T, baseURL, publishableKey string, emails *
 		t.Fatal("password reset: old password should not work after reset")
 	}
 }
-

--- a/internal/app/funcbundle_integration_test.go
+++ b/internal/app/funcbundle_integration_test.go
@@ -80,9 +80,8 @@ func TestServeConsumesBundleEndToEnd(t *testing.T) {
 		Project: domain.Project{Name: "funcs-bundle"},
 		Server:  domain.Server{Port: 0},
 		Auth: &domain.Auth{
-			JWTExpiry:     "1h",
-			RefreshTokens: false,
-			Email:         &domain.AuthEmail{VerifyEmail: false},
+			JWTExpiry: "1h",
+			Email:     &domain.AuthEmail{VerifyEmail: false},
 		},
 		Functions: map[string]domain.CodeFunction{
 			"greet": {Runtime: "node", File: "functions/greet.js"},
@@ -129,8 +128,8 @@ func TestServeConsumesBundleEndToEnd(t *testing.T) {
 
 	// ---- 4. Runtime from the EXTRACTED bundle. ----
 	rt, err := funcs.New(funcs.Options{
-		Dir:         dir,
-		Functions:   cfg.Functions,
+		Dir:            dir,
+		Functions:      cfg.Functions,
 		LoopbackURL:    "http://127.0.0.1:0",
 		PublishableKey: "inz_publishable_bundletest",
 		SecretKey:      "inz_secret_bundletest",
@@ -235,4 +234,3 @@ func buildInlineBundle(t *testing.T, files map[string]string) []byte {
 	}
 	return buf.Bytes()
 }
-

--- a/internal/app/migrate.go
+++ b/internal/app/migrate.go
@@ -523,6 +523,19 @@ func generateJWTKeysTable() []string {
 	}
 }
 
+// refreshTokensDDL is shared by generateAuthTables and diffNewAuth's
+// heal-existing-deployments path so the two stay in sync.
+const refreshTokensDDL = `CREATE TABLE IF NOT EXISTS auth.refresh_tokens (
+  id BIGSERIAL PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  token TEXT NOT NULL UNIQUE,
+  expires_at TIMESTAMPTZ NOT NULL,
+  session_id TEXT,
+  ip TEXT,
+  user_agent TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);`
+
 // generateAuthTables emits the auth.* tables. All tables live in the auth
 // schema; the underscore prefixes used pre-schema-move are dropped because
 // the schema already provides the namespace. Names align with Supabase's
@@ -570,16 +583,7 @@ func generateAuthTables(auth *domain.Auth) []string {
   UNIQUE(provider, provider_user_id)
 );`)
 
-	ddl = append(ddl, `CREATE TABLE IF NOT EXISTS auth.refresh_tokens (
-  id BIGSERIAL PRIMARY KEY,
-  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
-  token TEXT NOT NULL UNIQUE,
-  expires_at TIMESTAMPTZ NOT NULL,
-  session_id TEXT,
-  ip TEXT,
-  user_agent TEXT,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);`)
+	ddl = append(ddl, refreshTokensDDL)
 
 	if auth.Email != nil {
 		ddl = append(ddl, `CREATE TABLE IF NOT EXISTS auth.one_time_tokens (

--- a/internal/app/migrate.go
+++ b/internal/app/migrate.go
@@ -570,7 +570,7 @@ func generateAuthTables(auth *domain.Auth) []string {
   UNIQUE(provider, provider_user_id)
 );`)
 
-	if auth.RefreshTokens {
+	if auth.RefreshTokens != nil && *auth.RefreshTokens {
 		ddl = append(ddl, `CREATE TABLE IF NOT EXISTS auth.refresh_tokens (
   id BIGSERIAL PRIMARY KEY,
   user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,

--- a/internal/app/migrate.go
+++ b/internal/app/migrate.go
@@ -570,8 +570,7 @@ func generateAuthTables(auth *domain.Auth) []string {
   UNIQUE(provider, provider_user_id)
 );`)
 
-	if auth.RefreshTokens != nil && *auth.RefreshTokens {
-		ddl = append(ddl, `CREATE TABLE IF NOT EXISTS auth.refresh_tokens (
+	ddl = append(ddl, `CREATE TABLE IF NOT EXISTS auth.refresh_tokens (
   id BIGSERIAL PRIMARY KEY,
   user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
   token TEXT NOT NULL UNIQUE,
@@ -581,7 +580,6 @@ func generateAuthTables(auth *domain.Auth) []string {
   user_agent TEXT,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );`)
-	}
 
 	if auth.Email != nil {
 		ddl = append(ddl, `CREATE TABLE IF NOT EXISTS auth.one_time_tokens (

--- a/internal/app/migrate_config_diff.go
+++ b/internal/app/migrate_config_diff.go
@@ -337,16 +337,7 @@ func diffNewAuth(old, new *domain.Config) []string {
 	// Heal deployments from before refresh tokens were always-on: an existing
 	// auth block may predate the table and diffNewTables never sees it since
 	// it isn't declared in domain.Config.Tables.
-	ddl = append(ddl, `CREATE TABLE IF NOT EXISTS auth.refresh_tokens (
-  id BIGSERIAL PRIMARY KEY,
-  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
-  token TEXT NOT NULL UNIQUE,
-  expires_at TIMESTAMPTZ NOT NULL,
-  session_id TEXT,
-  ip TEXT,
-  user_agent TEXT,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);`)
+	ddl = append(ddl, refreshTokensDDL)
 	// Handle transition to email verification
 	if new.Auth.Email != nil && old.Auth.Email == nil {
 		ddl = append(ddl, `CREATE TABLE IF NOT EXISTS auth.one_time_tokens (

--- a/internal/app/migrate_config_diff.go
+++ b/internal/app/migrate_config_diff.go
@@ -335,7 +335,7 @@ func diffNewAuth(old, new *domain.Config) []string {
 	}
 	var ddl []string
 	// Handle transition to refresh tokens
-	if new.Auth.RefreshTokens && !old.Auth.RefreshTokens {
+	if (new.Auth.RefreshTokens != nil && *new.Auth.RefreshTokens) && !(old.Auth.RefreshTokens != nil && *old.Auth.RefreshTokens) {
 		ddl = append(ddl, `CREATE TABLE IF NOT EXISTS auth.refresh_tokens (
   id BIGSERIAL PRIMARY KEY,
   user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,

--- a/internal/app/migrate_config_diff.go
+++ b/internal/app/migrate_config_diff.go
@@ -334,19 +334,6 @@ func diffNewAuth(old, new *domain.Config) []string {
 		return generateAuthTables(new.Auth)
 	}
 	var ddl []string
-	// Handle transition to refresh tokens
-	if (new.Auth.RefreshTokens != nil && *new.Auth.RefreshTokens) && !(old.Auth.RefreshTokens != nil && *old.Auth.RefreshTokens) {
-		ddl = append(ddl, `CREATE TABLE IF NOT EXISTS auth.refresh_tokens (
-  id BIGSERIAL PRIMARY KEY,
-  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
-  token TEXT NOT NULL UNIQUE,
-  expires_at TIMESTAMPTZ NOT NULL,
-  session_id TEXT,
-  ip TEXT,
-  user_agent TEXT,
-  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);`)
-	}
 	// Handle transition to email verification
 	if new.Auth.Email != nil && old.Auth.Email == nil {
 		ddl = append(ddl, `CREATE TABLE IF NOT EXISTS auth.one_time_tokens (

--- a/internal/app/migrate_config_diff.go
+++ b/internal/app/migrate_config_diff.go
@@ -334,6 +334,19 @@ func diffNewAuth(old, new *domain.Config) []string {
 		return generateAuthTables(new.Auth)
 	}
 	var ddl []string
+	// Heal deployments from before refresh tokens were always-on: an existing
+	// auth block may predate the table and diffNewTables never sees it since
+	// it isn't declared in domain.Config.Tables.
+	ddl = append(ddl, `CREATE TABLE IF NOT EXISTS auth.refresh_tokens (
+  id BIGSERIAL PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  token TEXT NOT NULL UNIQUE,
+  expires_at TIMESTAMPTZ NOT NULL,
+  session_id TEXT,
+  ip TEXT,
+  user_agent TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);`)
 	// Handle transition to email verification
 	if new.Auth.Email != nil && old.Auth.Email == nil {
 		ddl = append(ddl, `CREATE TABLE IF NOT EXISTS auth.one_time_tokens (

--- a/internal/app/migrate_config_diff.go
+++ b/internal/app/migrate_config_diff.go
@@ -325,7 +325,7 @@ func rpcFunctionDropSig(fn domain.Function) string {
 
 // diffNewAuth returns DDL for auth table additions. If auth is newly added,
 // generates the full auth schema. If auth already existed, handles additive
-// schema changes (refresh tokens, email verification).
+// schema changes (email verification).
 func diffNewAuth(old, new *domain.Config) []string {
 	if new.Auth == nil {
 		return nil

--- a/internal/app/migrate_config_diff_test.go
+++ b/internal/app/migrate_config_diff_test.go
@@ -707,8 +707,7 @@ func TestDiffConfigs_NewAuth(t *testing.T) {
 	old := &domain.Config{}
 	new := &domain.Config{
 		Auth: &domain.Auth{
-			RefreshTokens: true,
-			Email:         &domain.AuthEmail{VerifyEmail: true},
+			Email: &domain.AuthEmail{VerifyEmail: true},
 		},
 		Tables: map[string]domain.Table{
 			"users": {Fields: []domain.Field{
@@ -723,24 +722,6 @@ func TestDiffConfigs_NewAuth(t *testing.T) {
 	mustContain(t, joined, "CREATE TABLE IF NOT EXISTS auth.users")
 	mustContain(t, joined, "CREATE TABLE IF NOT EXISTS auth.refresh_tokens")
 	mustContain(t, joined, "CREATE TABLE IF NOT EXISTS auth.one_time_tokens")
-}
-
-func TestDiffConfigs_AuthRefreshTokensAdded(t *testing.T) {
-	old := &domain.Config{
-		Auth: &domain.Auth{
-			RefreshTokens: false,
-		},
-	}
-	new := &domain.Config{
-		Auth: &domain.Auth{
-			RefreshTokens: true,
-		},
-	}
-
-	diff := diffConfigs(old, new)
-	joined := strings.Join(diff.Additions, "\n")
-
-	mustContain(t, joined, "CREATE TABLE IF NOT EXISTS auth.refresh_tokens")
 }
 
 func TestDiffConfigs_NormalizeType(t *testing.T) {

--- a/internal/app/migrate_config_diff_test.go
+++ b/internal/app/migrate_config_diff_test.go
@@ -724,6 +724,24 @@ func TestDiffConfigs_NewAuth(t *testing.T) {
 	mustContain(t, joined, "CREATE TABLE IF NOT EXISTS auth.one_time_tokens")
 }
 
+// TestDiffConfigs_ExistingAuthGetsRefreshTokensTable covers an upgrade from a
+// pre-always-on deployment: auth was already configured but never had
+// refresh_tokens enabled, so the table was never created. The additive diff
+// path must heal it.
+func TestDiffConfigs_ExistingAuthGetsRefreshTokensTable(t *testing.T) {
+	old := &domain.Config{
+		Auth: &domain.Auth{},
+	}
+	new := &domain.Config{
+		Auth: &domain.Auth{},
+	}
+
+	diff := diffConfigs(old, new)
+	joined := strings.Join(diff.Additions, "\n")
+
+	mustContain(t, joined, "CREATE TABLE IF NOT EXISTS auth.refresh_tokens")
+}
+
 func TestDiffConfigs_NormalizeType(t *testing.T) {
 	tests := []struct {
 		input string

--- a/internal/app/migrate_integration_test.go
+++ b/internal/app/migrate_integration_test.go
@@ -458,9 +458,9 @@ func TestIntegration_RPCFunction_CreateAndRemove(t *testing.T) {
 	}
 
 	cfgV2 := &domain.Config{
-		Version:   1,
-		Tables:    map[string]domain.Table{},
-		RPC: map[string]domain.Function{},
+		Version: 1,
+		Tables:  map[string]domain.Table{},
+		RPC:     map[string]domain.Function{},
 	}
 
 	if err := migrator.Apply(ctx, cfgV2); err != nil {
@@ -1246,8 +1246,7 @@ func TestIntegration_AuthUsersTable(t *testing.T) {
 	cfg := &domain.Config{
 		Version: 1,
 		Auth: &domain.Auth{
-			RefreshTokens: true,
-			Email:         &domain.AuthEmail{VerifyEmail: true},
+			Email: &domain.AuthEmail{VerifyEmail: true},
 		},
 		Tables: map[string]domain.Table{},
 	}

--- a/internal/app/migrate_integration_test.go
+++ b/internal/app/migrate_integration_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/instancez/instancez/internal/adapter/postgres"
 	"github.com/instancez/instancez/internal/app"
+	"github.com/instancez/instancez/internal/config"
 	"github.com/instancez/instancez/internal/domain"
 	"github.com/instancez/instancez/internal/testutil/dbboot"
 )
@@ -1288,6 +1289,38 @@ func TestIntegration_AuthUsersTable(t *testing.T) {
 	}
 	if fmt.Sprint(row["role"]) != "anon" {
 		t.Fatalf("expected 'anon' role, got %v", row["role"])
+	}
+}
+
+func TestMigrate_AuthProvisionedWithoutAuthBlock(t *testing.T) {
+	db := startPostgres(t)
+	ctx := context.Background()
+
+	yaml := []byte(`
+version: 1
+project:
+  name: "test"
+tables: {}
+`)
+	cfg, err := config.ParseBytes(yaml, "test.yaml")
+	if err != nil {
+		t.Fatalf("ParseBytes: %v", err)
+	}
+	config.ApplyDefaults(cfg)
+	if cfg.Auth == nil {
+		t.Fatal("loader must always populate Auth (always-on)")
+	}
+
+	migrator := app.NewMigrator(db).AllowDestructive(true)
+	if err := migrator.Apply(ctx, cfg); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	if !tableExists(t, db, "auth.users") {
+		t.Fatal("auth.users should exist without an auth: block in the config")
+	}
+	if !tableExists(t, db, "auth.refresh_tokens") {
+		t.Fatal("auth.refresh_tokens should exist without an auth: block in the config")
 	}
 }
 

--- a/internal/app/migrate_test.go
+++ b/internal/app/migrate_test.go
@@ -153,8 +153,7 @@ func TestGenerateTable_Default(t *testing.T) {
 
 func TestGenerateAuthTables(t *testing.T) {
 	auth := &domain.Auth{
-		RefreshTokens: true,
-		Email:         &domain.AuthEmail{VerifyEmail: true},
+		Email: &domain.AuthEmail{VerifyEmail: true},
 	}
 	ddl := generateAuthTables(auth)
 	joined := strings.Join(ddl, "\n")
@@ -197,21 +196,6 @@ func TestPlanUpdate_ReassertsJWTKeys(t *testing.T) {
 	joined := strings.Join(planUpdateStatements(oldCfg, newCfg, domain.DefaultRoles()), "\n")
 
 	mustContain(t, joined, "CREATE TABLE IF NOT EXISTS auth.jwt_keys")
-}
-
-func TestGenerateAuthTables_NoRefreshTokens(t *testing.T) {
-	auth := &domain.Auth{
-		RefreshTokens: false,
-	}
-	ddl := generateAuthTables(auth)
-	joined := strings.Join(ddl, "\n")
-
-	if strings.Contains(joined, "auth.refresh_tokens") {
-		t.Error("should not create auth.refresh_tokens when refresh_tokens is false")
-	}
-	if strings.Contains(joined, "auth.one_time_tokens") {
-		t.Error("should not create auth.one_time_tokens when email is nil")
-	}
 }
 
 func TestGenerateRLSPolicies(t *testing.T) {
@@ -728,8 +712,8 @@ func TestQualifiedTableName(t *testing.T) {
 
 func TestRLSAndIndexesUseQualifiedNames(t *testing.T) {
 	tbl := domain.Table{
-		Schema: "analytics",
-		Fields: []domain.Field{{Name: "id", Type: "BIGINT", PrimaryKey: true}},
+		Schema:  "analytics",
+		Fields:  []domain.Field{{Name: "id", Type: "BIGINT", PrimaryKey: true}},
 		Indexes: []domain.Index{{Columns: []string{"id"}}},
 		RLS: []domain.RLSPolicy{
 			{Operations: []string{"select"}, Using: "true"},
@@ -767,4 +751,3 @@ func TestOrderedSchemasOmitsAuthWhenUnconfigured(t *testing.T) {
 		t.Errorf("orderedSchemas with no auth/storage: got %v, want [public]", got)
 	}
 }
-

--- a/internal/app/migrate_test.go
+++ b/internal/app/migrate_test.go
@@ -174,6 +174,14 @@ func TestGenerateAuthTables(t *testing.T) {
 	mustContain(t, joined, "CREATE TABLE IF NOT EXISTS auth.flow_state")
 }
 
+func TestGenerateAuthTables_AlwaysIncludesRefreshTokens(t *testing.T) {
+	ddl := generateAuthTables(&domain.Auth{})
+	joined := strings.Join(ddl, "\n")
+	if !strings.Contains(joined, "CREATE TABLE IF NOT EXISTS auth.refresh_tokens") {
+		t.Fatal("auth.refresh_tokens must always be created (refresh tokens are always-on)")
+	}
+}
+
 // A config without an auth block must still create auth.jwt_keys: the migrator
 // emits it for every app so the JWKS endpoint and user-token verification work
 // even with user-facing auth disabled. Regression for the "relation

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -196,7 +196,6 @@ providers:
 
 auth:
   jwt_expiry: 15m
-  refresh_tokens: true
   refresh_token_expiry: 7d
 
   email:

--- a/internal/config/auth_alwayson_test.go
+++ b/internal/config/auth_alwayson_test.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"bytes"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/instancez/instancez/internal/domain"
@@ -25,5 +28,32 @@ func TestApplyDefaults_EmptyAuthBlockGetsDefaults(t *testing.T) {
 	ApplyDefaults(cfg)
 	if cfg.Auth.JWTExpiry != "15m" {
 		t.Errorf("JWTExpiry = %q, want 15m", cfg.Auth.JWTExpiry)
+	}
+}
+
+func TestApplyDefaults_RefreshTokensDeprecationWarning(t *testing.T) {
+	var buf bytes.Buffer
+	old := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	defer slog.SetDefault(old)
+
+	no := false
+	cfg := &domain.Config{Auth: &domain.Auth{RefreshTokens: &no}}
+	ApplyDefaults(cfg)
+
+	if !strings.Contains(buf.String(), "refresh_tokens") {
+		t.Errorf("expected deprecation warning mentioning refresh_tokens, got: %q", buf.String())
+	}
+}
+
+func TestApplyDefaults_NoWarningWhenRefreshTokensUnset(t *testing.T) {
+	var buf bytes.Buffer
+	old := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	defer slog.SetDefault(old)
+
+	ApplyDefaults(&domain.Config{}) // unset
+	if strings.Contains(buf.String(), "refresh_tokens") {
+		t.Errorf("no warning expected when refresh_tokens unset, got: %q", buf.String())
 	}
 }

--- a/internal/config/auth_alwayson_test.go
+++ b/internal/config/auth_alwayson_test.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/instancez/instancez/internal/domain"
+)
+
+func TestApplyDefaults_AuthAlwaysPopulated(t *testing.T) {
+	cfg := &domain.Config{} // no auth: block
+	ApplyDefaults(cfg)
+	if cfg.Auth == nil {
+		t.Fatal("Auth must be non-nil after ApplyDefaults (auth is always-on)")
+	}
+	if cfg.Auth.JWTExpiry == "" {
+		t.Errorf("JWTExpiry default not applied: %q", cfg.Auth.JWTExpiry)
+	}
+	if cfg.Auth.RefreshTokenExpiry == "" {
+		t.Errorf("RefreshTokenExpiry default not applied: %q", cfg.Auth.RefreshTokenExpiry)
+	}
+}
+
+func TestApplyDefaults_EmptyAuthBlockGetsDefaults(t *testing.T) {
+	cfg := &domain.Config{Auth: &domain.Auth{}} // auth: {}
+	ApplyDefaults(cfg)
+	if cfg.Auth.JWTExpiry != "15m" {
+		t.Errorf("JWTExpiry = %q, want 15m", cfg.Auth.JWTExpiry)
+	}
+}

--- a/internal/config/auth_alwayson_test.go
+++ b/internal/config/auth_alwayson_test.go
@@ -46,6 +46,26 @@ func TestApplyDefaults_RefreshTokensDeprecationWarning(t *testing.T) {
 	}
 }
 
+// TestParseBytes_DeprecatedRefreshTokensFalseAccepted proves the strict YAML
+// decoder still accepts old config with auth.refresh_tokens: false (no
+// unknown-key/type error) and ignores it — refresh tokens stay always-on.
+func TestParseBytes_DeprecatedRefreshTokensFalseAccepted(t *testing.T) {
+	src := []byte("version: 1\nauth:\n  refresh_tokens: false\n")
+	cfg, err := ParseBytes(src, "test.yaml")
+	if err != nil {
+		t.Fatalf("strict decode should accept deprecated refresh_tokens key, got: %v", err)
+	}
+	if cfg.Auth == nil {
+		t.Fatal("Auth must be non-nil (always-on)")
+	}
+	if cfg.Auth.RefreshTokens == nil || *cfg.Auth.RefreshTokens != false {
+		t.Errorf("RefreshTokens should decode to a pointer to false, got %v", cfg.Auth.RefreshTokens)
+	}
+	if cfg.Auth.RefreshTokenExpiry == "" {
+		t.Error("RefreshTokenExpiry default should still be applied despite the ignored toggle")
+	}
+}
+
 func TestApplyDefaults_NoWarningWhenRefreshTokensUnset(t *testing.T) {
 	var buf bytes.Buffer
 	old := slog.Default()

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -3,6 +3,7 @@ package config
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"regexp"
 	"strings"
@@ -249,8 +250,7 @@ func applyDefaults(cfg *domain.Config) {
 		cfg.Database.Pool.IdleTimeout = "300s"
 	}
 
-	// Auth is always-on: ensure the block exists so auth is provisioned even
-	// when the config omits it.
+	// Auth is always-on: never nil after defaults.
 	if cfg.Auth == nil {
 		cfg.Auth = &domain.Auth{}
 	}
@@ -259,6 +259,9 @@ func applyDefaults(cfg *domain.Config) {
 	}
 	if cfg.Auth.RefreshTokenExpiry == "" {
 		cfg.Auth.RefreshTokenExpiry = "7d"
+	}
+	if cfg.Auth.RefreshTokens != nil && !*cfg.Auth.RefreshTokens {
+		slog.Warn("auth.refresh_tokens is deprecated and ignored; refresh tokens are always enabled")
 	}
 
 	// RPC: fill defaults and derive ReturnCategory.

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -249,14 +249,16 @@ func applyDefaults(cfg *domain.Config) {
 		cfg.Database.Pool.IdleTimeout = "300s"
 	}
 
-	// Auth defaults
-	if cfg.Auth != nil {
-		if cfg.Auth.JWTExpiry == "" {
-			cfg.Auth.JWTExpiry = "15m"
-		}
-		if cfg.Auth.RefreshTokenExpiry == "" && cfg.Auth.RefreshTokens {
-			cfg.Auth.RefreshTokenExpiry = "7d"
-		}
+	// Auth is always-on: ensure the block exists so auth is provisioned even
+	// when the config omits it.
+	if cfg.Auth == nil {
+		cfg.Auth = &domain.Auth{}
+	}
+	if cfg.Auth.JWTExpiry == "" {
+		cfg.Auth.JWTExpiry = "15m"
+	}
+	if cfg.Auth.RefreshTokenExpiry == "" {
+		cfg.Auth.RefreshTokenExpiry = "7d"
 	}
 
 	// RPC: fill defaults and derive ReturnCategory.

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -504,9 +504,8 @@ func TestValidate_FullExampleConfig(t *testing.T) {
 			Storage: &domain.StorageProvider{Type: "s3", Bucket: "${INSTANCEZ_S3_BUCKET}"},
 		},
 		Auth: &domain.Auth{
-			JWTExpiry:     "15m",
-			RefreshTokens: true,
-			Email:         &domain.AuthEmail{VerifyEmail: true},
+			JWTExpiry: "15m",
+			Email:     &domain.AuthEmail{VerifyEmail: true},
 		},
 		Tables: map[string]domain.Table{
 			"users": {
@@ -571,9 +570,8 @@ func TestValidate_UnknownEmailTemplateRejected(t *testing.T) {
 	withTemplates := func(templates map[string]domain.EmailTemplate) *domain.Config {
 		cfg := validBaseConfig()
 		cfg.Auth = &domain.Auth{
-			JWTExpiry:     "15m",
-			RefreshTokens: true,
-			Email:         &domain.AuthEmail{VerifyEmail: true, Templates: templates},
+			JWTExpiry: "15m",
+			Email:     &domain.AuthEmail{VerifyEmail: true, Templates: templates},
 		}
 		return cfg
 	}

--- a/internal/domain/schema.go
+++ b/internal/domain/schema.go
@@ -11,16 +11,16 @@ import (
 
 // Config is the top-level Instancez configuration parsed from YAML.
 type Config struct {
-	Version    int                     `yaml:"version" json:"version"`
-	Project    Project                 `yaml:"project" json:"project"`
-	Database   DatabaseConfig          `yaml:"database" json:"database"`
-	Server     Server                  `yaml:"server" json:"server"`
-	Providers  Providers               `yaml:"providers" json:"providers"`
-	Auth       *Auth                   `yaml:"auth" json:"auth"`
-	Tables     map[string]Table        `yaml:"tables" json:"tables"`
-	Storage    map[string]Bucket       `yaml:"storage" json:"storage"`
-	RPC        map[string]Function     `yaml:"rpc" json:"rpc"`
-	Functions  map[string]CodeFunction `yaml:"functions" json:"functions"`
+	Version   int                     `yaml:"version" json:"version"`
+	Project   Project                 `yaml:"project" json:"project"`
+	Database  DatabaseConfig          `yaml:"database" json:"database"`
+	Server    Server                  `yaml:"server" json:"server"`
+	Providers Providers               `yaml:"providers" json:"providers"`
+	Auth      *Auth                   `yaml:"auth" json:"auth"`
+	Tables    map[string]Table        `yaml:"tables" json:"tables"`
+	Storage   map[string]Bucket       `yaml:"storage" json:"storage"`
+	RPC       map[string]Function     `yaml:"rpc" json:"rpc"`
+	Functions map[string]CodeFunction `yaml:"functions" json:"functions"`
 	// FunctionsBundle is a pointer to the pre-built functions bundle that
 	// `serve` consumes at runtime (it never builds). For self-hosted deployments,
 	// `inz bundle` builds the bundle (vendoring node_modules), uploads it, and
@@ -38,7 +38,6 @@ type Config struct {
 	// serialized — the decoders populate it, Validate reads it.
 	UnknownKeys ValidationErrors `yaml:"-" json:"-"`
 }
-
 
 // Project holds display-only metadata.
 type Project struct {
@@ -118,11 +117,12 @@ type StorageProvider struct {
 // false" (public registration is disabled). Always read them through the
 // SignupAllowed() / AnonymousAllowed() helpers.
 type Auth struct {
-	JWTExpiry          string         `yaml:"jwt_expiry" json:"jwt_expiry"`
-	RefreshTokens      bool           `yaml:"refresh_tokens" json:"refresh_tokens"`
-	RefreshTokenExpiry string         `yaml:"refresh_token_expiry" json:"refresh_token_expiry"`
-	AllowSignup        *bool          `yaml:"allow_signup" json:"allow_signup"`
-	AllowAnonymous     *bool          `yaml:"allow_anonymous" json:"allow_anonymous"`
+	JWTExpiry string `yaml:"jwt_expiry" json:"jwt_expiry"`
+	// RefreshTokens is deprecated and ignored; refresh tokens are always issued.
+	RefreshTokens      *bool  `yaml:"refresh_tokens" json:"refresh_tokens"`
+	RefreshTokenExpiry string `yaml:"refresh_token_expiry" json:"refresh_token_expiry"`
+	AllowSignup        *bool  `yaml:"allow_signup" json:"allow_signup"`
+	AllowAnonymous     *bool  `yaml:"allow_anonymous" json:"allow_anonymous"`
 	// RedirectURLs is the allowlist of external origins that post-auth flows
 	// (password recovery, email verification, OAuth) may redirect to. The
 	// server's own base URL is always allowed; relative same-origin paths are
@@ -343,10 +343,10 @@ type Index struct {
 // be set explicitly. See validateRLS in internal/config/validate.go for the
 // exact rule.
 type RLSPolicy struct {
-	Operations []string `yaml:"operations" json:"operations"`               // exactly one of select/insert/update/delete, or all four
-	Using      string   `yaml:"using,omitempty" json:"using,omitempty"`         // SQL boolean expression
+	Operations []string `yaml:"operations" json:"operations"`                     // exactly one of select/insert/update/delete, or all four
+	Using      string   `yaml:"using,omitempty" json:"using,omitempty"`           // SQL boolean expression
 	WithCheck  string   `yaml:"with_check,omitempty" json:"with_check,omitempty"` // SQL boolean expression
-	Type       string   `yaml:"type,omitempty" json:"type,omitempty"`       // permissive (default) | restrictive
+	Type       string   `yaml:"type,omitempty" json:"type,omitempty"`             // permissive (default) | restrictive
 }
 
 // Bucket defines a storage bucket.
@@ -446,4 +446,3 @@ type Migration struct {
 	ConfigJSON string    `json:"config_json"`
 	AppliedAt  time.Time `json:"applied_at"`
 }
-

--- a/internal/domain/schema_test.go
+++ b/internal/domain/schema_test.go
@@ -32,16 +32,6 @@ func TestAuth_IsRedirectAllowed(t *testing.T) {
 			t.Errorf("IsRedirectAllowed(%q) = %v, want %v", tc.target, got, tc.want)
 		}
 	}
-
-	// A nil Auth still permits the base origin and relative paths, and rejects
-	// foreign origins.
-	var nilAuth *Auth
-	if !nilAuth.IsRedirectAllowed("https://app.example.com/x", base) {
-		t.Error("nil Auth should allow the base origin")
-	}
-	if nilAuth.IsRedirectAllowed("https://evil.com", base) {
-		t.Error("nil Auth should reject foreign origins")
-	}
 }
 
 // Nil defaults to allowed: this is the backward-compatibility contract for

--- a/internal/domain/schema_test.go
+++ b/internal/domain/schema_test.go
@@ -34,6 +34,18 @@ func TestAuth_IsRedirectAllowed(t *testing.T) {
 	}
 }
 
+// IsRedirectAllowed must be safe on a nil *Auth (no configured allowlist).
+func TestAuth_IsRedirectAllowed_NilReceiver(t *testing.T) {
+	var a *Auth
+	const base = "https://app.example.com"
+	if !a.IsRedirectAllowed("/reset", base) {
+		t.Error("relative path should be allowed on nil receiver")
+	}
+	if a.IsRedirectAllowed("https://evil.com", base) {
+		t.Error("off-origin absolute URL should be rejected on nil receiver")
+	}
+}
+
 // Nil defaults to allowed: this is the backward-compatibility contract for
 // configs written before the flags existed.
 func TestAuth_SignupAllowed_DefaultsTrue(t *testing.T) {


### PR DESCRIPTION
## What this changes

Makes **auth and refresh tokens always-on**, removing them as opt-in toggles.

- **Auth is always provisioned.** There was never an `auth.enabled` flag — auth was gated by *presence* of the `auth:` block (`Config.Auth` was `nil` when omitted). The loader now populates `cfg.Auth` when the block is absent, so `/auth/v1/*` routes and the `auth.*` schema are always created. The `auth:` block becomes optional tuning. Existing `if cfg.Auth != nil` guards stay as nil-safety for programmatically-built configs.
- **Refresh tokens are always issued.** `auth.refresh_tokens` is deprecated (accept-but-ignore): the key still decodes under the strict YAML decoder so old configs don't break, but its value is ignored and a one-line deprecation warning is logged when it's explicitly `false`. The three handler gates and the migrate gate are removed; `auth.refresh_tokens` is now part of the base auth schema.

Nothing else was made always-on: REST/CRUD already is, and storage/email require provider credentials so can't be forced.

### Upgrade behavior (the important bit)

The old default for `refresh_tokens` was `false`, so an existing deployment that had an `auth:` block but never set `refresh_tokens: true` has **no `auth.refresh_tokens` table**. Since handlers now always insert refresh tokens, `diffNewAuth` re-asserts `CREATE TABLE IF NOT EXISTS auth.refresh_tokens` on the update path (`old.Auth != nil`), so those deployments heal on the next migrate. Idempotent via `IF NOT EXISTS`; dataloss/DROP gating is unaffected.

## Checklist

- [x] `go build ./...` passes
- [x] `go test -race ./...` passes
- [x] `go test -tags=integration -race ./...` passes for the packages I touched (needs Docker) — config, app, adapter/http (incl. pgrupstream/postgrest conformance)
- [x] `npm test` passes in `dashboard/` (329 tests) — removed the dead "Enable refresh tokens" toggle
- [x] The supabase-js compatibility test still passes — `TestSupabaseJSCompat` ✅ green with always-on
- [x] Docs and examples in `docs/site/` are updated (config reference, auth guide, examples, samples, scaffold)

## Notes for reviewers

- **Dashboard:** the "Enable refresh tokens" toggle was removed (it would have silently no-op'd against the always-on backend).
- **Deleted tests:** `TestGenerateAuthTables_NoRefreshTokens` and `TestDiffConfigs_AuthRefreshTokensAdded` asserted the *opposite* of the new contract; replaced by `TestGenerateAuthTables_AlwaysIncludesRefreshTokens` and `TestDiffConfigs_ExistingAuthGetsRefreshTokensTable` (the upgrade-heal regression test).
- **DDL:** the `auth.refresh_tokens` CREATE is hoisted to a single `const refreshTokensDDL` shared by `generateAuthTables` and `diffNewAuth` (was verbatim-duplicated).
- **Not run locally:** `golangci-lint` (relying on CI's pinned version); `go vet -tags=integration` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
