### PR TITLE
fix(http/cors): reflect requested headers so new supabase-js headers pass

### DIFF
--- a/internal/adapter/http/middleware.go
+++ b/internal/adapter/http/middleware.go
@@ -152,11 +152,17 @@ func corsMiddleware(cfg domain.CORS, devMode bool) gin.HandlerFunc {
 
 		c.Header("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS")
 
-		// Includes the headers supabase-js attaches on every request (apikey,
-		// x-client-info) plus the PostgREST schema selectors (content-profile,
-		// accept-profile) and the existing set. Not app-configurable — no app
-		// has a reason to add custom headers to a supabase-js-shaped API.
-		c.Header("Access-Control-Allow-Headers", "Authorization, Content-Type, Prefer, Accept, apikey, x-client-info, Range, Range-Unit, Content-Profile, Accept-Profile, X-Requested-With")
+		// Reflect the headers the client asks for on the preflight. supabase-js
+		// keeps adding request headers over time (apikey, x-client-info, and now
+		// x-supabase-api-version), so a fixed allow-list goes stale and silently
+		// blocks the preflight. Reflecting keeps this correct for any supabase-js
+		// version; the known supabase/PostgREST set is the fallback when the
+		// preflight names none (or on a non-preflight response).
+		allowHeaders := "Authorization, Content-Type, Prefer, Accept, apikey, x-client-info, x-supabase-api-version, Range, Range-Unit, Content-Profile, Accept-Profile, X-Requested-With"
+		if requested := c.GetHeader("Access-Control-Request-Headers"); requested != "" {
+			allowHeaders = requested
+		}
+		c.Header("Access-Control-Allow-Headers", allowHeaders)
 		c.Header("Access-Control-Expose-Headers", "Content-Range, Content-Profile, Location")
 		c.Header("Access-Control-Max-Age", "86400")
 

--- a/internal/adapter/http/middleware_test.go
+++ b/internal/adapter/http/middleware_test.go
@@ -115,6 +115,41 @@ func TestCorsMiddleware(t *testing.T) {
 			t.Errorf("Access-Control-Max-Age = %q, want 86400", got)
 		}
 	})
+
+	t.Run("preflight reflects requested headers so new supabase-js headers pass", func(t *testing.T) {
+		r := gin.New()
+		r.Use(corsMiddleware(domain.CORS{Origins: []string{"*"}}, false))
+		r.OPTIONS("/x", func(c *gin.Context) {})
+
+		req := httptest.NewRequest(http.MethodOptions, "/x", nil)
+		req.Header.Set("Origin", "http://localhost:5173")
+		req.Header.Set("Access-Control-Request-Method", "POST")
+		req.Header.Set("Access-Control-Request-Headers", "authorization,apikey,x-supabase-api-version")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		// The exact set the client asked for is echoed — including a header the
+		// old fixed list omitted (x-supabase-api-version).
+		if got := w.Header().Get("Access-Control-Allow-Headers"); got != "authorization,apikey,x-supabase-api-version" {
+			t.Errorf("Access-Control-Allow-Headers = %q, want the reflected request headers", got)
+		}
+	})
+
+	t.Run("without a requested-headers preflight, the known set is served", func(t *testing.T) {
+		r := gin.New()
+		r.Use(corsMiddleware(domain.CORS{Origins: []string{"*"}}, false))
+		r.GET("/x", func(c *gin.Context) { c.Status(200) })
+
+		req := httptest.NewRequest(http.MethodGet, "/x", nil)
+		req.Header.Set("Origin", "http://localhost:5173")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		got := w.Header().Get("Access-Control-Allow-Headers")
+		if !strings.Contains(got, "x-supabase-api-version") || !strings.Contains(got, "Authorization") {
+			t.Errorf("fallback Access-Control-Allow-Headers = %q, want the known supabase set", got)
+		}
+	})
 }
 
 func TestProfileHeaderGuard(t *testing.T) {


### PR DESCRIPTION
## Problem

The CORS `Access-Control-Allow-Headers` response was a **fixed list**. supabase-js
adds request headers over time, and the current one — `x-supabase-api-version` —
was **not** in the list, so browsers blocked the preflight of *every* cross-origin
request (auth, rest, functions, storage) with:

> Request header field x-supabase-api-version is not allowed by
> Access-Control-Allow-Headers in preflight response.

Same-origin apps never send a preflight, so this stayed latent until a backend-only
app with a separate browser frontend hit it.

## Fix

Reflect the preflight's `Access-Control-Request-Headers` into
`Access-Control-Allow-Headers`, falling back to the known supabase/PostgREST set
(now including `x-supabase-api-version`) when the preflight names none. This keeps
CORS correct for any supabase-js version without chasing new header names.

Only `Access-Control-Allow-Headers` changes — origin gating and the
never-set `Access-Control-Allow-Credentials` are untouched.

## This matches Supabase's own behavior

- **Kong** (Supabase's gateway) configures the CORS plugin with no `headers` field,
  so Kong **reflects** `Access-Control-Request-Headers`.
- **PostgREST** reflects the requested headers too (`src/library/PostgREST/Cors.hs`).
- **GoTrue** uses a fixed list but explicitly added `X-Supabase-Api-Version` after
  hitting this exact bug (`supabase/auth#1589`).

## Security

Reviewed: safe. `Allow-Headers` doesn't gate response reads (that's `Allow-Origin`,
unchanged) and doesn't authenticate. With no `Allow-Credentials` and bearer-token
auth (no ambient cookies), reflecting the requested header *names* grants a
cross-origin page no capability it didn't already have; RLS still gates all data.
Go's `net/http` rejects CR/LF in response header values, so the reflected value
can't split headers.

## Tests

`internal/adapter/http/middleware_test.go`: a preflight with
`x-supabase-api-version` gets it reflected back; the no-requested-headers path
serves the known fallback set. Full `http` package tests + `go vet` pass.