### PR TITLE
feat(functions): drop apikey requirement so webhooks can reach /functions/v1

### DIFF
--- a/docs/site/src/content/docs/build/functions.md
+++ b/docs/site/src/content/docs/build/functions.md
@@ -218,6 +218,8 @@ const { data, error } = await supabase.functions.invoke("todos", {
 });
 ```
 
+Unlike `/rest/v1`, `/auth/v1`, and `/storage/v1`, functions do **not** require the `apikey` header. This lets external webhook senders that can't attach your publishable key reach a function directly. A webhook function must verify the sender's own signature (use `rawBody`) and should keep `auth_required: false`, since the caller has no user JWT.
+
 ## Lifecycle
 
 | Command | npm | Hot reload |

--- a/internal/adapter/http/functions_no_apikey_test.go
+++ b/internal/adapter/http/functions_no_apikey_test.go
@@ -12,42 +12,66 @@ import (
 	"github.com/instancez/instancez/internal/domain"
 )
 
-// TestFunctionsReachableWithoutApikey: a keyless POST reaches /functions/v1
-// while the same keyless request to /rest/v1 stays guarded by apiKeyGuard.
-func TestFunctionsReachableWithoutApikey(t *testing.T) {
+// TestFunctionsApikeyOptional: /functions/v1 validates the apikey only when
+// present. A keyless webhook caller reaches the runtime; a valid key reaches
+// it too; a garbage key is rejected 401 before invoke. The /rest/v1 control
+// proves apiKeyGuard is untouched elsewhere.
+func TestFunctionsApikeyOptional(t *testing.T) {
 	gin.SetMode(gin.TestMode)
+	t.Setenv("INSTANCEZ_PUBLISHABLE_KEY", "inz_publishable_fntest")
+	t.Setenv("INSTANCEZ_SECRET_KEY", "inz_secret_fntest")
 
 	cfg, err := config.ParseBytes([]byte("version: 1\nproject:\n  name: \"test\"\ntables: {}\n"), "test.yaml")
 	if err != nil {
 		t.Fatalf("ParseBytes: %v", err)
 	}
 
-	rt := &fakeRuntime{known: map[string]*domain.FunctionResponse{
-		"hook": {Status: 200, Body: []byte(`{"ok":true}`)},
-	}}
-	deps := ServerDeps{
-		Config:          cfg,
-		DB:              domain.RequestDB{Database: &stubDB{}},
-		Logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
-		DashboardMode:   DashboardDisabled,
-		JWTKeys:         stubKeys(t),
-		FunctionRuntime: rt,
+	newHandler := func(rt *fakeRuntime) http.Handler {
+		return NewServer(ServerDeps{
+			Config:          cfg,
+			DB:              domain.RequestDB{Database: &stubDB{}},
+			Logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+			DashboardMode:   DashboardDisabled,
+			JWTKeys:         stubKeys(t),
+			FunctionRuntime: rt,
+		}).Handler()
 	}
-	handler := NewServer(deps).Handler()
 
-	// Function: keyless POST reaches the runtime and returns its body.
+	cases := []struct {
+		name        string
+		apikey      string
+		wantStatus  int
+		wantInvoked bool
+	}{
+		{"keyless webhook reaches runtime", "", 200, true},
+		{"publishable key reaches runtime", "inz_publishable_fntest", 200, true},
+		{"secret key reaches runtime", "inz_secret_fntest", 200, true},
+		{"garbage key rejected before invoke", "not-a-real-key", 401, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := &fakeRuntime{known: map[string]*domain.FunctionResponse{
+				"hook": {Status: 200, Body: []byte(`{"ok":true}`)},
+			}}
+			req := httptest.NewRequest(http.MethodPost, "/functions/v1/hook", nil)
+			if tc.apikey != "" {
+				req.Header.Set("apikey", tc.apikey)
+			}
+			w := httptest.NewRecorder()
+			newHandler(rt).ServeHTTP(w, req)
+
+			if w.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d (body: %s)", w.Code, tc.wantStatus, w.Body.String())
+			}
+			if rt.invokeCalled != tc.wantInvoked {
+				t.Fatalf("invokeCalled = %v, want %v", rt.invokeCalled, tc.wantInvoked)
+			}
+		})
+	}
+
+	// Control: /rest/v1 without apikey is still hard-required (rpc route exists).
 	w := httptest.NewRecorder()
-	handler.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/functions/v1/hook", nil))
-	if w.Code != http.StatusOK {
-		t.Fatalf("keyless function call: want 200, got %d (body: %s)", w.Code, w.Body.String())
-	}
-	if !rt.invokeCalled {
-		t.Fatal("runtime must be invoked for a keyless function call")
-	}
-
-	// Control: /rest/v1 without apikey is still guarded (rpc route always exists).
-	w = httptest.NewRecorder()
-	handler.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/rest/v1/rpc/anything", nil))
+	newHandler(&fakeRuntime{}).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/rest/v1/rpc/anything", nil))
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("keyless /rest/v1: want 401 (apiKeyGuard intact), got %d (body: %s)", w.Code, w.Body.String())
 	}

--- a/internal/adapter/http/functions_no_apikey_test.go
+++ b/internal/adapter/http/functions_no_apikey_test.go
@@ -1,0 +1,54 @@
+package http
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/instancez/instancez/internal/config"
+	"github.com/instancez/instancez/internal/domain"
+)
+
+// TestFunctionsReachableWithoutApikey: a keyless POST reaches /functions/v1
+// while the same keyless request to /rest/v1 stays guarded by apiKeyGuard.
+func TestFunctionsReachableWithoutApikey(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cfg, err := config.ParseBytes([]byte("version: 1\nproject:\n  name: \"test\"\ntables: {}\n"), "test.yaml")
+	if err != nil {
+		t.Fatalf("ParseBytes: %v", err)
+	}
+
+	rt := &fakeRuntime{known: map[string]*domain.FunctionResponse{
+		"hook": {Status: 200, Body: []byte(`{"ok":true}`)},
+	}}
+	deps := ServerDeps{
+		Config:          cfg,
+		DB:              domain.RequestDB{Database: &stubDB{}},
+		Logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+		DashboardMode:   DashboardDisabled,
+		JWTKeys:         stubKeys(t),
+		FunctionRuntime: rt,
+	}
+	handler := NewServer(deps).Handler()
+
+	// Function: keyless POST reaches the runtime and returns its body.
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/functions/v1/hook", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("keyless function call: want 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+	if !rt.invokeCalled {
+		t.Fatal("runtime must be invoked for a keyless function call")
+	}
+
+	// Control: /rest/v1 without apikey is still guarded (rpc route always exists).
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/rest/v1/rpc/anything", nil))
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("keyless /rest/v1: want 401 (apiKeyGuard intact), got %d (body: %s)", w.Code, w.Body.String())
+	}
+}

--- a/internal/adapter/http/middleware.go
+++ b/internal/adapter/http/middleware.go
@@ -365,6 +365,22 @@ func jwtAuth(keys *app.JWTKeyManager, required bool) gin.HandlerFunc {
 	}
 }
 
+// apiKeyOptional validates the apikey header only when it is present: a
+// keyless caller (a webhook that can't attach our key) passes through, while a
+// present-but-invalid key is rejected instead of silently downgraded to anon.
+// Used on /functions/v1.
+func apiKeyOptional(keys *app.JWTKeyManager) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		key := c.GetHeader("apikey")
+		if keys == nil || key == "" || keyTier(key) != tierNone {
+			c.Next()
+			return
+		}
+		pgJSON(c, 401, "invalid_api_key", "Invalid API key", "", "")
+		c.Abort()
+	}
+}
+
 // apiKeyGuard enforces the apikey header supabase-js attaches to every request:
 // it must be the publishable or secret key. keys == nil means a unit test built
 // the handler without key support; skip the check rather than fail every such

--- a/internal/adapter/http/server.go
+++ b/internal/adapter/http/server.go
@@ -113,11 +113,9 @@ func NewServer(deps ServerDeps) *Server {
 	crudHandler := NewCRUDHandler(deps)
 	crudHandler.Mount(root)
 
-	// Code functions at /functions/v1/:name — same JWT gate as /rest/v1.
-	// FunctionRuntime may be nil (returns 501) so existing call sites that
-	// do not set FunctionRuntime continue to compile and work unchanged.
+	// Code functions at /functions/v1/:name — no apiKeyGuard so webhook senders
+	// without our apikey can reach them; per-function auth_required still gates.
 	functionsV1 := root.Group("/functions/v1")
-	functionsV1.Use(apiKeyGuard(deps.JWTKeys))
 	functionsV1.Use(jwtAuth(deps.JWTKeys, false))
 	NewFunctionsHandler(deps.FunctionRuntime).Mount(functionsV1)
 

--- a/internal/adapter/http/server.go
+++ b/internal/adapter/http/server.go
@@ -113,9 +113,11 @@ func NewServer(deps ServerDeps) *Server {
 	crudHandler := NewCRUDHandler(deps)
 	crudHandler.Mount(root)
 
-	// Code functions at /functions/v1/:name — no apiKeyGuard so webhook senders
-	// without our apikey can reach them; per-function auth_required still gates.
+	// Code functions at /functions/v1/:name. apiKeyOptional (not apiKeyGuard) so
+	// keyless webhook senders get in, but a present-but-bad key is still 401'd;
+	// per-function auth_required gates the rest.
 	functionsV1 := root.Group("/functions/v1")
+	functionsV1.Use(apiKeyOptional(deps.JWTKeys))
 	functionsV1.Use(jwtAuth(deps.JWTKeys, false))
 	NewFunctionsHandler(deps.FunctionRuntime).Mount(functionsV1)
 


### PR DESCRIPTION
## What

`/functions/v1` no longer hard-requires the `apikey` header. It uses `apiKeyOptional` instead of `apiKeyGuard`:

- **apikey absent** → allowed (webhook path), resolves to `anon`
- **apikey present & valid** (publishable/secret) → validated as before; secret still maps to `service_role`
- **apikey present but invalid** → `401 invalid_api_key` (not a silent anon downgrade)

## Why

External webhook senders (Stripe, GitHub, …) can't attach our publishable key — which is a client-safe string anyway, not access control. This opens the keyless path while keeping real supabase-js clients (which always send the pubkey) validated, and still giving a typo'd key a clear 401.

## Unchanged
- `apiKeyGuard` stays on `/rest/v1`, `/auth/v1`, `/storage/v1` — supabase-js contract intact.
- Per-function `auth_required: true` still 401s anonymous callers.
- Webhook functions must verify their own signature (`rawBody`) and keep `auth_required: false`.

## Tests
- `TestFunctionsApikeyOptional` (table): keyless→200, publishable→200, secret→200, garbage→401-before-invoke, plus `/rest/v1`→401 control.
- The apikey gate is HTTP-middleware logic exercised deterministically at the handler level; a real-runtime integration test would cover Node, not this path, so it's intentionally unit-tested. The funcs integration suite already proves real functions execute.
- `go build`, `go vet`, `go test -race ./...` green; `TestSupabaseJSCompat` (integration) green — compat unaffected.

## Docs
`docs/site/src/content/docs/build/functions.md` — Calling a function.