### PR TITLE
feat(cli): inz cloud frontend deploy + cloud-side config validation

### DIFF
--- a/internal/cli/cloud.go
+++ b/internal/cli/cloud.go
@@ -17,6 +17,7 @@ func newCloudCmd() *cobra.Command {
 		newWhoamiCmd(),
 		newDeployCmd(),
 		newStatusCmd(),
+		newFrontendCmd(),
 	)
 	return cmd
 }

--- a/internal/cli/cloud_errors.go
+++ b/internal/cli/cloud_errors.go
@@ -33,6 +33,26 @@ func reportCloudErr(action string, err error) error {
 	return errReported
 }
 
+// reportCloudProblems renders a slice of blocking validation problems (from the
+// cloud validate endpoint, which returns them with a 200 rather than as an
+// APIError) in the same shape as reportCloudErr, and returns errReported so
+// Execute doesn't also print a bare error. Returns nil when there are none.
+func reportCloudProblems(action string, problems []cloud.Problem) error {
+	if len(problems) == 0 {
+		return nil
+	}
+	fmt.Fprintf(os.Stderr, "\n  ✗ %s failed cloud validation:\n", action)
+	for _, p := range problems {
+		fmt.Fprintf(os.Stderr, "\n    %s\n", p.Path)
+		fmt.Fprintf(os.Stderr, "    %s\n", p.Message)
+		if p.Suggestion != "" {
+			fmt.Fprintf(os.Stderr, "    Suggestion: %s\n", p.Suggestion)
+		}
+	}
+	fmt.Fprintf(os.Stderr, "\n  Found %d problem(s)\n", len(problems))
+	return errReported
+}
+
 // printDropped prints one warning line per entry a successful UploadYAML
 // reported as dropped (providers content stripped before persisting, since
 // it's inert in the cloud runtime). Used by both `inz cloud deploy` and

--- a/internal/cli/deploy.go
+++ b/internal/cli/deploy.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/instancez/instancez/internal/cli/preflight"
 	"github.com/instancez/instancez/internal/cloud"
 	"github.com/instancez/instancez/internal/config"
 	"github.com/spf13/cobra"
@@ -83,13 +82,6 @@ func runDeploy(configPath string, opts deployOpts) error {
 		return err
 	}
 
-	if r, failed := preflight.RunUntilFail([]preflight.Check{
-		preflight.ConfigValidCheck(configPath),
-	}); failed {
-		fmt.Fprintf(os.Stderr, "  ✗ %s — %s\n    hint: %s\n", r.Name, r.Detail, r.FixHint)
-		return errReported
-	}
-
 	src, err := os.ReadFile(configPath)
 	if err != nil {
 		return fmt.Errorf("read %s: %w", configPath, err)
@@ -125,6 +117,19 @@ func runDeploy(configPath string, opts deployOpts) error {
 	}
 
 	c := cloud.NewClient(cloud.APIURL(), creds.PAT)
+
+	// Validate against the cloud's own policy rules (server-side, projectless),
+	// the authority a deploy is checked by — rather than the stricter OSS local
+	// validator, which rejects configs the cloud accepts (e.g. it auto-provides
+	// s3 storage). Blocking problems stop the deploy; dropped entries are warned.
+	problems, dropped, err := c.ValidateConfigCloud(string(src))
+	if err != nil {
+		return reportCloudErr("validate config", err)
+	}
+	if perr := reportCloudProblems("deploy", problems); perr != nil {
+		return perr
+	}
+	printDropped(dropped)
 
 	// Confirm before anything is written OR created, so declining leaves nothing
 	// behind: no cloud project, no project_id in the local yaml, no sources.

--- a/internal/cli/deploy_test.go
+++ b/internal/cli/deploy_test.go
@@ -145,6 +145,12 @@ func uploadYAMLResponseBody(diffHasChanges bool) string {
 	return string(b)
 }
 
+// validateConfigOK is the happy-path response for the pre-deploy cloud
+// validation call (POST /instancez/validate-config): no blocking problems.
+const validateConfigOK = `{"problems":[],"dropped":[]}`
+
+const validateConfigPath = "/instancez/validate-config"
+
 // TestRunDeployPromptsAndDeclineAborts: deploy always previews and prompts;
 // declining means the write call never happens.
 func TestRunDeployPromptsAndDeclineAborts(t *testing.T) {
@@ -233,6 +239,10 @@ func TestRunDeployAcceptWrites(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls = append(calls, r.Method+" "+r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == validateConfigPath {
+			_, _ = w.Write([]byte(validateConfigOK))
+			return
+		}
 		var body struct {
 			Branch string `json:"branch"`
 		}
@@ -256,6 +266,7 @@ func TestRunDeployAcceptWrites(t *testing.T) {
 	cfg := writeDeployConfig(t, home)
 	require.NoError(t, runDeploy(cfg, deployOpts{}))
 	assert.Equal(t, []string{
+		"POST " + validateConfigPath,
 		"POST /instancez/projects/abc/config/preview",
 		"PUT /instancez/projects/abc/yaml",
 	}, calls)
@@ -367,16 +378,29 @@ func TestRunDeployMissingProjectID(t *testing.T) {
 	assert.ErrorContains(t, err, "--new")
 }
 
+// Cloud validation rejects the config (server-side), so deploy fails with a
+// reported error before touching the project.
 func TestRunDeployInvalidYAML(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	require.NoError(t, cloud.Save(cloud.Credentials{PAT: "tok-123"}))
-	t.Setenv("INSTANCEZ_CLOUD_API", "http://127.0.0.1:1")
 
-	p := filepath.Join(home, "instancez.yaml")
-	require.NoError(t, os.WriteFile(p, []byte("version: 99\n"), 0o644))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == validateConfigPath {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"problems": []map[string]string{{"path": "version", "message": "unsupported version"}},
+				"dropped":  []any{},
+			})
+			return
+		}
+		t.Errorf("unexpected request past validation: %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+	t.Setenv("INSTANCEZ_CLOUD_API", srv.URL)
 
-	err := runDeploy(p, deployOpts{})
+	cfg := writeDeployConfig(t, home)
+	err := runDeploy(cfg, deployOpts{})
 	assert.ErrorIs(t, err, errReported)
 }
 
@@ -396,6 +420,8 @@ func TestRunDeployNewCreatesProjectAfterValidation(t *testing.T) {
 		calls = append(calls, r.Method+" "+r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
 		switch {
+		case r.URL.Path == validateConfigPath:
+			_, _ = w.Write([]byte(validateConfigOK))
 		case r.Method == "POST" && r.URL.Path == "/instancez/projects":
 			_ = json.NewEncoder(w).Encode(map[string]any{"project_id": "newly-created", "slug": "s", "name": "demo"})
 		case r.Method == "POST" && r.URL.Path == "/instancez/projects/newly-created/config/preview":
@@ -416,9 +442,10 @@ func TestRunDeployNewCreatesProjectAfterValidation(t *testing.T) {
 	require.NoError(t, os.WriteFile(cfgPath, []byte("version: 1\nproject:\n  name: demo\n"), 0o644))
 
 	require.NoError(t, runDeploy(cfgPath, deployOpts{new: true, yes: true}))
-	// A brand-new project has no remote state to diff, so deploy skips preview
-	// and goes straight from create to upload.
+	// Config is cloud-validated first, then (a brand-new project has no remote
+	// state to diff) deploy skips preview and goes straight from create to upload.
 	assert.Equal(t, []string{
+		"POST " + validateConfigPath,
 		"POST /instancez/projects",
 		"PUT /instancez/projects/newly-created/yaml",
 	}, calls)
@@ -469,17 +496,36 @@ func TestRunDeployNewDeclineNeverCreatesProject(t *testing.T) {
 	assert.Equal(t, original, string(after), "declining must not write a project_id into the yaml")
 }
 
+// Cloud validation runs BEFORE project creation, so an invalid config with
+// --new fails without ever creating a project (no orphan).
 func TestRunDeployNewFailsValidationBeforeCreatingProject(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	require.NoError(t, cloud.Save(cloud.Credentials{PAT: "tok-123"}))
-	t.Setenv("INSTANCEZ_CLOUD_API", "http://127.0.0.1:1")
+
+	createCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == validateConfigPath:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"problems": []map[string]string{{"path": "version", "message": "unsupported version"}},
+				"dropped":  []any{},
+			})
+		case r.Method == "POST" && r.URL.Path == "/instancez/projects":
+			createCalled = true
+			_ = json.NewEncoder(w).Encode(map[string]any{"project_id": "x"})
+		}
+	}))
+	defer srv.Close()
+	t.Setenv("INSTANCEZ_CLOUD_API", srv.URL)
 
 	cfgPath := filepath.Join(home, "instancez.yaml")
-	require.NoError(t, os.WriteFile(cfgPath, []byte("version: 99\n"), 0o644))
+	require.NoError(t, os.WriteFile(cfgPath, []byte("version: 1\nproject:\n  name: demo\n"), 0o644))
 
 	err := runDeploy(cfgPath, deployOpts{new: true})
 	assert.ErrorIs(t, err, errReported)
+	assert.False(t, createCalled, "must not create a project when cloud validation fails")
 }
 
 func TestRunDeployNewErrorsWhenAlreadyLinked(t *testing.T) {
@@ -510,6 +556,7 @@ func TestRunDeployProjectFlagOverridesFile(t *testing.T) {
 	cfg := writeDeployConfig(t, home)
 	require.NoError(t, runDeploy(cfg, deployOpts{project: "override-id", yes: true}))
 	assert.Equal(t, []string{
+		"POST " + validateConfigPath,
 		"POST /instancez/projects/override-id/config/preview",
 		"PUT /instancez/projects/override-id/yaml",
 	}, calls)

--- a/internal/cli/frontend.go
+++ b/internal/cli/frontend.go
@@ -29,7 +29,7 @@ func newFrontendCmd() *cobra.Command {
 }
 
 func newFrontendDeployCmd() *cobra.Command {
-	var configPath, project string
+	var configPath, project, branch string
 	cmd := &cobra.Command{
 		Use:   "deploy <dist-dir>",
 		Short: "Upload a prebuilt static bundle (dist/) as the project's frontend",
@@ -38,19 +38,22 @@ func newFrontendDeployCmd() *cobra.Command {
 The bundle is served at the project's domain while /api still routes to the
 backend. <dist-dir> must contain an index.html at its root (a Vite/SPA build).
 
-The project id is read from project.cloud.project_id in instancez.yaml, or
-pass --project to target one directly.`,
+--branch selects which version to deploy to (validated server-side against the
+app's versions). The project id is read from project.cloud.project_id in
+instancez.yaml, or pass --project to target one directly.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runFrontendDeploy(args[0], configPath, project)
+			return runFrontendDeploy(args[0], configPath, project, branch)
 		},
 	}
 	cmd.Flags().StringVar(&configPath, "config", "instancez.yaml", "path to instancez.yaml (for the linked project id)")
 	cmd.Flags().StringVar(&project, "project", "", "target this cloud project id instead of instancez.yaml's project.cloud.project_id")
+	cmd.Flags().StringVar(&branch, "branch", "", "branch/version to deploy the frontend to (validated server-side)")
+	_ = cmd.MarkFlagRequired("branch")
 	return cmd
 }
 
-func runFrontendDeploy(distDir, configPath, project string) error {
+func runFrontendDeploy(distDir, configPath, project, branch string) error {
 	projectID := project
 	if projectID == "" {
 		src, err := os.ReadFile(configPath)
@@ -76,10 +79,10 @@ func runFrontendDeploy(distDir, configPath, project string) error {
 		return err
 	}
 	c := cloud.NewClient(cloud.APIURL(), creds.PAT)
-	if err := c.UploadFrontend(projectID, files); err != nil {
+	if err := c.UploadFrontend(projectID, branch, files); err != nil {
 		return err
 	}
-	fmt.Printf("  ✓ Deployed %d file(s) from %s\n", len(files), distDir)
+	fmt.Printf("  ✓ Deployed %d file(s) from %s to %s\n", len(files), distDir, branch)
 	return nil
 }
 

--- a/internal/cli/frontend.go
+++ b/internal/cli/frontend.go
@@ -1,0 +1,132 @@
+package cli
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/instancez/instancez/internal/cloud"
+	"github.com/spf13/cobra"
+)
+
+// Client-side guards mirroring the cloud's, so an obviously-bad bundle fails
+// fast without a round-trip. The server enforces the same limits authoritatively.
+const (
+	maxFrontendFiles = 5000
+	maxFrontendBytes = 100 << 20 // 100 MiB
+)
+
+// newFrontendCmd groups a project's static-frontend commands under
+// `inz cloud frontend`.
+func newFrontendCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "frontend",
+		Short: "Manage a project's static frontend",
+	}
+	cmd.AddCommand(newFrontendDeployCmd())
+	return cmd
+}
+
+func newFrontendDeployCmd() *cobra.Command {
+	var configPath, project string
+	cmd := &cobra.Command{
+		Use:   "deploy <dist-dir>",
+		Short: "Upload a prebuilt static bundle (dist/) as the project's frontend",
+		Long: `Upload an externally-built static frontend bundle to an instancez Cloud project.
+
+The bundle is served at the project's domain while /api still routes to the
+backend. <dist-dir> must contain an index.html at its root (a Vite/SPA build).
+
+The project id is read from project.cloud.project_id in instancez.yaml, or
+pass --project to target one directly.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runFrontendDeploy(args[0], configPath, project)
+		},
+	}
+	cmd.Flags().StringVar(&configPath, "config", "instancez.yaml", "path to instancez.yaml (for the linked project id)")
+	cmd.Flags().StringVar(&project, "project", "", "target this cloud project id instead of instancez.yaml's project.cloud.project_id")
+	return cmd
+}
+
+func runFrontendDeploy(distDir, configPath, project string) error {
+	projectID := project
+	if projectID == "" {
+		src, err := os.ReadFile(configPath)
+		if err != nil {
+			return fmt.Errorf("read %s: %w (or pass --project <id>)", configPath, err)
+		}
+		projectID, err = cloud.ReadProjectID(src)
+		if err != nil {
+			return fmt.Errorf("parse %s: %w", configPath, err)
+		}
+	}
+	if projectID == "" {
+		return fmt.Errorf("no project linked; set project.cloud.project_id or pass --project <id>")
+	}
+
+	files, err := collectFrontendFiles(distDir)
+	if err != nil {
+		return err
+	}
+
+	creds, err := ensureLoggedIn(ensureLoginOpts{})
+	if err != nil {
+		return err
+	}
+	c := cloud.NewClient(cloud.APIURL(), creds.PAT)
+	if err := c.UploadFrontend(projectID, files); err != nil {
+		return err
+	}
+	fmt.Printf("  ✓ Deployed %d file(s) from %s\n", len(files), distDir)
+	return nil
+}
+
+// collectFrontendFiles walks distDir into a base64-encoded, forward-slash
+// path-keyed map (keys relative to distDir). It enforces the cloud's index.html,
+// count, and size limits client-side so an obviously-bad bundle fails fast.
+func collectFrontendFiles(distDir string) (map[string]string, error) {
+	info, err := os.Stat(distDir)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", distDir, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%s is not a directory", distDir)
+	}
+
+	files := map[string]string{}
+	var total int64
+	err = filepath.WalkDir(distDir, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(distDir, p)
+		if err != nil {
+			return err
+		}
+		body, err := os.ReadFile(p)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", rel, err)
+		}
+		total += int64(len(body))
+		if total > maxFrontendBytes {
+			return fmt.Errorf("bundle too large (> %d bytes)", maxFrontendBytes)
+		}
+		if len(files) >= maxFrontendFiles {
+			return fmt.Errorf("too many files (> %d)", maxFrontendFiles)
+		}
+		files[filepath.ToSlash(rel)] = base64.StdEncoding.EncodeToString(body)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if _, ok := files["index.html"]; !ok {
+		return nil, fmt.Errorf("%s has no index.html at its root", distDir)
+	}
+	return files, nil
+}

--- a/internal/cli/frontend_cloud_test.go
+++ b/internal/cli/frontend_cloud_test.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/instancez/instancez/internal/cloud"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeCfg(t *testing.T, dir, body string) string {
+	t.Helper()
+	p := filepath.Join(dir, "instancez.yaml")
+	require.NoError(t, os.WriteFile(p, []byte(body), 0o644))
+	return p
+}
+
+func TestValidateAgainstCloud_ProblemsReportedError(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	require.NoError(t, cloud.Save(cloud.Credentials{PAT: "tok"}))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/instancez/validate-config", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"problems":[{"path":"version","message":"unsupported"}],"dropped":[]}`))
+	}))
+	defer srv.Close()
+	t.Setenv("INSTANCEZ_CLOUD_API", srv.URL)
+
+	cfg := writeCfg(t, dir, "version: 99\n")
+	err := validateAgainstCloud(context.Background(), cfg, false)
+	assert.ErrorIs(t, err, errReported)
+}
+
+func TestValidateAgainstCloud_CleanSucceeds(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	require.NoError(t, cloud.Save(cloud.Credentials{PAT: "tok"}))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"problems":[],"dropped":[]}`))
+	}))
+	defer srv.Close()
+	t.Setenv("INSTANCEZ_CLOUD_API", srv.URL)
+
+	cfg := writeCfg(t, dir, "version: 1\nproject:\n  name: d\n")
+	require.NoError(t, validateAgainstCloud(context.Background(), cfg, false))
+}
+
+func TestValidateAgainstCloud_RequiresAuth(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir) // no credentials saved
+	cfg := writeCfg(t, dir, "version: 1\nproject:\n  name: d\n")
+	err := validateAgainstCloud(context.Background(), cfg, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "authentication")
+}
+
+func TestRunFrontendDeploy_PostsBundleToBranch(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	require.NoError(t, cloud.Save(cloud.Credentials{PAT: "tok"}))
+
+	var gotPath string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+	t.Setenv("INSTANCEZ_CLOUD_API", srv.URL)
+
+	cfg := writeCfg(t, dir, "version: 1\nproject:\n  cloud:\n    project_id: abc\n")
+	dist := filepath.Join(dir, "dist")
+	require.NoError(t, os.MkdirAll(filepath.Join(dist, "assets"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dist, "index.html"), []byte("<html>"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dist, "assets", "a.js"), []byte("x"), 0o644))
+
+	require.NoError(t, runFrontendDeploy(dist, cfg, "", "production"))
+
+	assert.Equal(t, "/instancez/projects/abc/frontend", gotPath)
+	assert.Equal(t, "production", gotBody["branch"])
+	files := gotBody["files"].(map[string]any)
+	assert.Contains(t, files, "index.html")
+	assert.Contains(t, files, "assets/a.js")
+}
+
+func TestRunFrontendDeploy_RejectsMissingIndex(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	require.NoError(t, cloud.Save(cloud.Credentials{PAT: "tok"}))
+	t.Setenv("INSTANCEZ_CLOUD_API", "http://127.0.0.1:1")
+
+	cfg := writeCfg(t, dir, "version: 1\nproject:\n  cloud:\n    project_id: abc\n")
+	dist := filepath.Join(dir, "dist")
+	require.NoError(t, os.MkdirAll(dist, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dist, "app.js"), []byte("x"), 0o644)) // no index.html
+
+	err := runFrontendDeploy(dist, cfg, "", "production")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "index.html")
+}

--- a/internal/cli/frontend_test.go
+++ b/internal/cli/frontend_test.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeDistFile(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	p := filepath.Join(dir, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCollectFrontendFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeDistFile(t, dir, "index.html", "<!doctype html>")
+	writeDistFile(t, dir, "assets/app.abc.js", "console.log(1)")
+	writeDistFile(t, dir, "nested/page/data.json", "{}")
+
+	files, err := collectFrontendFiles(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(files) != 3 {
+		t.Fatalf("want 3 files, got %d: %v", len(files), files)
+	}
+	// forward-slash keys, relative to dir
+	for _, want := range []string{"index.html", "assets/app.abc.js", "nested/page/data.json"} {
+		if _, ok := files[want]; !ok {
+			t.Errorf("missing key %q in %v", want, files)
+		}
+	}
+	// contents are base64-encoded round-trippable
+	raw, err := base64.StdEncoding.DecodeString(files["index.html"])
+	if err != nil || string(raw) != "<!doctype html>" {
+		t.Errorf("index.html decode = %q, %v", raw, err)
+	}
+}
+
+func TestCollectFrontendFiles_NoIndex(t *testing.T) {
+	dir := t.TempDir()
+	writeDistFile(t, dir, "assets/app.js", "x")
+	if _, err := collectFrontendFiles(dir); err == nil {
+		t.Fatal("expected error when index.html is missing")
+	}
+}
+
+func TestCollectFrontendFiles_NotADir(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "index.html")
+	if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := collectFrontendFiles(f); err == nil {
+		t.Fatal("expected error when path is a file, not a dir")
+	}
+}

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -18,10 +18,11 @@ import (
 
 func newValidateCmd() *cobra.Command {
 	var (
-		configPath string
-		jsonOutput bool
-		useDSN     string
-		project    string
+		configPath    string
+		jsonOutput    bool
+		useDSN        string
+		project       string
+		cloudValidate bool
 	)
 
 	cmd := &cobra.Command{
@@ -44,6 +45,15 @@ validate never creates a project and never writes anything server-side; use
 			if _, err := applyEnvDefaults(cmd.Flags(), nil, os.Getenv); err != nil {
 				return err
 			}
+			if cloudValidate {
+				if cmd.Flags().Changed("project") {
+					return errors.New("--cloud and --project are mutually exclusive (--cloud is projectless)")
+				}
+				if len(args) > 0 {
+					return fmt.Errorf("validate does not take positional arguments")
+				}
+				return validateAgainstCloud(cmd.Context(), configPath, jsonOutput)
+			}
 			if !cmd.Flags().Changed("project") {
 				if len(args) > 0 {
 					return fmt.Errorf("validate does not take positional arguments")
@@ -63,7 +73,43 @@ validate never creates a project and never writes anything server-side; use
 	cmd.Flags().StringVar(&useDSN, "use-dsn", "", "after syntax check, plan a migration against this owner-class DSN")
 	cmd.Flags().StringVar(&project, "project", "", "preview against a cloud project (bare --project uses instancez.yaml's project_id; --project <id> overrides it)")
 	cmd.Flags().Lookup("project").NoOptDefVal = useFileProjectID
+	cmd.Flags().BoolVar(&cloudValidate, "cloud", false, "validate against the cloud's policy rules server-side (projectless; the same rules a deploy enforces)")
 	return cmd
+}
+
+// validateAgainstCloud validates the local yaml against the cloud's policy rules
+// server-side, without a project and without writing anything. Backs `inz
+// validate --cloud`. Blocking problems exit non-zero; dropped entries are
+// non-blocking warnings.
+func validateAgainstCloud(ctx context.Context, configPath string, jsonOutput bool) error {
+	_ = ctx
+	if err := requireLocalConfig(configPath); err != nil {
+		return err
+	}
+	creds, err := cloud.Load()
+	if err != nil {
+		return fmt.Errorf("--cloud requires authentication: %w", err)
+	}
+	src, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", configPath, err)
+	}
+	c := cloud.NewClient(cloud.APIURL(), creds.PAT)
+	problems, dropped, err := c.ValidateConfigCloud(string(src))
+	if err != nil {
+		return reportCloudErr("validate config", err)
+	}
+	if jsonOutput {
+		return json.NewEncoder(os.Stdout).Encode(map[string]any{
+			"problems": problems, "dropped": dropped,
+		})
+	}
+	if perr := reportCloudProblems("validate", problems); perr != nil {
+		return perr
+	}
+	printDropped(dropped)
+	fmt.Println("  ✓ Cloud valid")
+	return nil
 }
 
 // useFileProjectID is the sentinel NoOptDefVal for --project, so bare

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -187,6 +187,16 @@ func (c *Client) UploadSecrets(projectID string, secrets map[string]string) erro
 		map[string]any{"secrets": secrets, "branch": wireBranch}, nil)
 }
 
+// UploadFrontend deploys an externally-built static bundle to the project's
+// frontend. files is path-keyed with base64-encoded contents (keys are relative
+// to the bundle root, e.g. "index.html", "assets/app.abc.js"). The cloud
+// validates it, uploads it under the version's frontend prefix, and redeploys.
+// Called by `inz cloud frontend deploy`.
+func (c *Client) UploadFrontend(projectID string, files map[string]string) error {
+	return c.do("POST", "/instancez/projects/"+projectID+"/frontend",
+		map[string]any{"files": files, "branch": wireBranch}, nil)
+}
+
 // GetAppResponse mirrors GET /instancez/projects/:id. It carries the project
 // fields plus the app's deploy state (Deployment). Note: Status is the
 // project lifecycle status, distinct from Deployment.Status (the deploy state).

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -187,14 +187,34 @@ func (c *Client) UploadSecrets(projectID string, secrets map[string]string) erro
 		map[string]any{"secrets": secrets, "branch": wireBranch}, nil)
 }
 
-// UploadFrontend deploys an externally-built static bundle to the project's
-// frontend. files is path-keyed with base64-encoded contents (keys are relative
-// to the bundle root, e.g. "index.html", "assets/app.abc.js"). The cloud
-// validates it, uploads it under the version's frontend prefix, and redeploys.
-// Called by `inz cloud frontend deploy`.
-func (c *Client) UploadFrontend(projectID string, files map[string]string) error {
+type validateConfigResponse struct {
+	Problems []Problem `json:"problems"`
+	Dropped  []Problem `json:"dropped"`
+}
+
+// ValidateConfigCloud validates yamlContent against the cloud's policy rules
+// server-side (projectless), the same rules a deploy enforces — more lenient
+// than the OSS local validator (e.g. cloud auto-provides s3 storage). Returns
+// blocking problems and non-blocking dropped entries. Backs `inz validate
+// --cloud` and the pre-deploy check.
+func (c *Client) ValidateConfigCloud(yamlContent string) (problems, dropped []Problem, err error) {
+	var out validateConfigResponse
+	if err := c.do("POST", "/instancez/validate-config",
+		map[string]string{"config": yamlContent}, &out); err != nil {
+		return nil, nil, err
+	}
+	return out.Problems, out.Dropped, nil
+}
+
+// UploadFrontend deploys an externally-built static bundle to the given branch
+// of the project's frontend. files is path-keyed with base64-encoded contents
+// (keys are relative to the bundle root, e.g. "index.html", "assets/app.abc.js").
+// branch is validated server-side against the app's versions. The cloud
+// validates the bundle, uploads it under that version's frontend prefix, and
+// redeploys. Called by `inz cloud frontend deploy`.
+func (c *Client) UploadFrontend(projectID, branch string, files map[string]string) error {
 	return c.do("POST", "/instancez/projects/"+projectID+"/frontend",
-		map[string]any{"files": files, "branch": wireBranch}, nil)
+		map[string]any{"files": files, "branch": branch}, nil)
 }
 
 // GetAppResponse mirrors GET /instancez/projects/:id. It carries the project

--- a/internal/cloud/frontend_client_test.go
+++ b/internal/cloud/frontend_client_test.go
@@ -1,0 +1,68 @@
+package cloud
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUploadFrontend_PostsFilesAndBranch(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "pat")
+	err := c.UploadFrontend("proj1", "production", map[string]string{"index.html": "PGh0bWw+"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "POST", gotMethod)
+	assert.Equal(t, "/instancez/projects/proj1/frontend", gotPath)
+	assert.Equal(t, "production", gotBody["branch"])
+	files := gotBody["files"].(map[string]any)
+	assert.Equal(t, "PGh0bWw+", files["index.html"])
+}
+
+func TestValidateConfigCloud_ParsesProblemsAndDropped(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"problems":[{"path":"tables.x","message":"bad"}],"dropped":[{"path":"providers.storage","message":"cloud-managed"}]}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "pat")
+	problems, dropped, err := c.ValidateConfigCloud("version: 1\n")
+	require.NoError(t, err)
+	assert.Equal(t, "/instancez/validate-config", gotPath)
+	require.Len(t, problems, 1)
+	assert.Equal(t, "tables.x", problems[0].Path)
+	require.Len(t, dropped, 1)
+	assert.Equal(t, "providers.storage", dropped[0].Path)
+}
+
+func TestValidateConfigCloud_CleanConfig(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"problems":[],"dropped":[]}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "pat")
+	problems, dropped, err := c.ValidateConfigCloud("version: 1\n")
+	require.NoError(t, err)
+	assert.Empty(t, problems)
+	assert.Empty(t, dropped)
+}


### PR DESCRIPTION
Adds the CLI side of external static-frontend hosting (platform PR:
instancez/instancez-platform#68).

## What
- `inz cloud frontend deploy <dist> --branch <name>`: walks a prebuilt dist/
  into a base64, path-keyed map and POSTs it to
  /instancez/projects/:id/frontend. --branch is required and validated
  server-side. Client-side checks (index.html present, size/count) fail fast.
- `inz validate --cloud`: projectless server-side validation against the
  cloud's policy rules (POST /instancez/validate-config) — more lenient than
  the OSS local validator (cloud auto-provides s3 storage).
- `inz cloud deploy` now validates via the cloud endpoint instead of the
  stricter OSS local validator, so a cloud-valid config is no longer falsely
  rejected; the check runs before project creation, so --new never orphans a
  project on an invalid config.

All new client/CLI paths are unit-tested (httptest); the platform deploy gate
exercises the real `inz cloud frontend deploy` end-to-end against dev.