### PR TITLE
fix(dashboard): SQL editor theming + run hotkey + schema autocomplete; auth always-on

### DIFF
--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -3,7 +3,6 @@ import type {
   ConfigStatus,
   StatsResponse,
   DiffResponse,
-  ValidationError,
   AdminUser,
   SqlResult,
 } from "../lib/types";

--- a/dashboard/src/components/CodeEditor.test.tsx
+++ b/dashboard/src/components/CodeEditor.test.tsx
@@ -1,8 +1,33 @@
 import { describe, it, expect, vi } from "vitest";
 import { useState } from "react";
-import { act } from "@testing-library/react";
+import { act, fireEvent } from "@testing-library/react";
 import { renderWithChakra } from "../test/helpers";
 import { CodeEditor } from "./CodeEditor";
+
+describe("CodeEditor onSubmit", () => {
+  it("fires onSubmit on Cmd/Ctrl+Enter, not a plain Enter", () => {
+    const onSubmit = vi.fn();
+    const { container } = renderWithChakra(
+      <CodeEditor value="select 1" onChange={vi.fn()} onSubmit={onSubmit} />
+    );
+    const content = container.querySelector(".cm-content")!;
+    fireEvent.keyDown(content, { key: "Enter" });
+    expect(onSubmit).not.toHaveBeenCalled();
+    fireEvent.keyDown(content, { key: "Enter", ctrlKey: true });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves Mod-Enter to the default (insert blank line) when no onSubmit", () => {
+    const onChange = vi.fn();
+    const { container } = renderWithChakra(
+      <CodeEditor value="select 1" onChange={onChange} />
+    );
+    const content = container.querySelector(".cm-content")!;
+    const before = container.querySelectorAll(".cm-line").length;
+    fireEvent.keyDown(content, { key: "Enter", ctrlKey: true });
+    expect(container.querySelectorAll(".cm-line").length).toBe(before + 1);
+  });
+});
 
 /**
  * The `frame` prop renders a fixed scaffold (header/footer) as real, locked

--- a/dashboard/src/components/CodeEditor.test.tsx
+++ b/dashboard/src/components/CodeEditor.test.tsx
@@ -10,7 +10,7 @@ describe("CodeEditor onSubmit", () => {
     const { container } = renderWithChakra(
       <CodeEditor value="select 1" onChange={vi.fn()} onSubmit={onSubmit} />
     );
-    const content = container.querySelector(".cm-content")!;
+    const content = container.querySelector(".cm-content") as HTMLElement;
     fireEvent.keyDown(content, { key: "Enter" });
     expect(onSubmit).not.toHaveBeenCalled();
     fireEvent.keyDown(content, { key: "Enter", ctrlKey: true });
@@ -22,7 +22,7 @@ describe("CodeEditor onSubmit", () => {
     const { container } = renderWithChakra(
       <CodeEditor value="select 1" onChange={onChange} />
     );
-    const content = container.querySelector(".cm-content")!;
+    const content = container.querySelector(".cm-content") as HTMLElement;
     const before = container.querySelectorAll(".cm-line").length;
     fireEvent.keyDown(content, { key: "Enter", ctrlKey: true });
     expect(container.querySelectorAll(".cm-line").length).toBe(before + 1);

--- a/dashboard/src/components/CodeEditor.test.tsx
+++ b/dashboard/src/components/CodeEditor.test.tsx
@@ -10,10 +10,10 @@ describe("CodeEditor onSubmit", () => {
     const { container } = renderWithChakra(
       <CodeEditor value="select 1" onChange={vi.fn()} onSubmit={onSubmit} />
     );
-    const content = container.querySelector(".cm-content") as HTMLElement;
-    fireEvent.keyDown(content, { key: "Enter" });
+    const editorEl = container.querySelector(".cm-content") as HTMLElement;
+    fireEvent.keyDown(editorEl, { key: "Enter" });
     expect(onSubmit).not.toHaveBeenCalled();
-    fireEvent.keyDown(content, { key: "Enter", ctrlKey: true });
+    fireEvent.keyDown(editorEl, { key: "Enter", ctrlKey: true });
     expect(onSubmit).toHaveBeenCalledTimes(1);
   });
 
@@ -22,9 +22,9 @@ describe("CodeEditor onSubmit", () => {
     const { container } = renderWithChakra(
       <CodeEditor value="select 1" onChange={onChange} />
     );
-    const content = container.querySelector(".cm-content") as HTMLElement;
+    const editorEl = container.querySelector(".cm-content") as HTMLElement;
     const before = container.querySelectorAll(".cm-line").length;
-    fireEvent.keyDown(content, { key: "Enter", ctrlKey: true });
+    fireEvent.keyDown(editorEl, { key: "Enter", ctrlKey: true });
     expect(container.querySelectorAll(".cm-line").length).toBe(before + 1);
   });
 });

--- a/dashboard/src/components/CodeEditor.tsx
+++ b/dashboard/src/components/CodeEditor.tsx
@@ -1,7 +1,7 @@
 import { useRef, useEffect } from "react";
 import { Box } from "@chakra-ui/react";
 import { EditorView, basicSetup } from "codemirror";
-import { Decoration, type DecorationSet } from "@codemirror/view";
+import { Decoration, keymap, type DecorationSet } from "@codemirror/view";
 import {
   EditorState,
   EditorSelection,
@@ -9,6 +9,7 @@ import {
   StateEffect,
   Annotation,
   Transaction,
+  Prec,
   type Extension,
   type SelectionRange,
   type TransactionSpec,
@@ -46,6 +47,28 @@ const brandTheme = EditorView.theme({
   // The locked scaffold lines: real code lines, just tinted so they read as
   // fixed and the caret never lands in them.
   ".cm-readonly-line": { backgroundColor: "var(--syn-readonly-line)" },
+  // The autocomplete popup. Without a darkTheme facet CodeMirror paints it with
+  // its light defaults, so force our vars for both modes.
+  ".cm-tooltip": {
+    backgroundColor: "var(--c-surface)",
+    color: "var(--c-foreground)",
+    border: "1px solid var(--c-border)",
+    borderRadius: "6px",
+  },
+  ".cm-tooltip.cm-tooltip-autocomplete > ul": {
+    fontFamily: "var(--font-mono)",
+    fontSize: "12px",
+  },
+  ".cm-tooltip-autocomplete ul li[aria-selected]": {
+    backgroundColor: "var(--syn-selection)",
+    color: "var(--c-foreground)",
+  },
+  ".cm-completionDetail": { color: "var(--c-muted-foreground)" },
+  ".cm-completionMatchedText": {
+    color: "var(--syn-keyword)",
+    textDecoration: "none",
+    fontWeight: "600",
+  },
 });
 
 export interface Frame {
@@ -223,6 +246,10 @@ interface CodeEditorProps {
       syntax-highlighted lines above and below the body and kept out of
       `value`/`onChange`. */
   frame?: Frame;
+  /** Fired on Cmd/Ctrl+Enter, e.g. to run the current query. */
+  onSubmit?: () => void;
+  /** Table → column names, fed to SQL autocompletion as known identifiers. */
+  sqlSchema?: Record<string, string[]>;
 }
 
 export function CodeEditor({
@@ -233,17 +260,35 @@ export function CodeEditor({
   minHeight = "120px",
   readOnly = false,
   frame,
+  onSubmit,
+  sqlSchema,
 }: CodeEditorProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
+  const onSubmitRef = useRef(onSubmit);
+  onSubmitRef.current = onSubmit;
 
   useEffect(() => {
     if (!containerRef.current) return;
     const initFrame = frame ?? null;
 
     const extensions = [
+      // Prec.highest so Mod-Enter wins over basicSetup, which binds it to
+      // insertBlankLine.
+      Prec.highest(
+        keymap.of([
+          {
+            key: "Mod-Enter",
+            run: () => {
+              if (!onSubmitRef.current) return false; // fall through to basicSetup
+              onSubmitRef.current();
+              return true;
+            },
+          },
+        ])
+      ),
       basicSetup,
       brandTheme,
       syntaxHighlighting(brandHighlight),
@@ -269,7 +314,8 @@ export function CodeEditor({
       }),
     ];
 
-    if (language === "sql") extensions.push(sql());
+    if (language === "sql")
+      extensions.push(sql(sqlSchema ? { schema: sqlSchema, upperCaseKeywords: false } : undefined));
     if (language === "javascript") extensions.push(javascript());
     if (readOnly) extensions.push(EditorState.readOnly.of(true));
     if (placeholder) {
@@ -292,7 +338,7 @@ export function CodeEditor({
     // Only re-create on language/readOnly change, not value. The frame and value
     // flow in through the effects below without tearing down the editor.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [language, readOnly, minHeight]);
+  }, [language, readOnly, minHeight, sqlSchema]);
 
   // Rewrite the scaffold in place when the frame prop changes (e.g. the RPC
   // header recomputing from form fields). The body and the caret stay put.

--- a/dashboard/src/components/TagInput.tsx
+++ b/dashboard/src/components/TagInput.tsx
@@ -1,5 +1,4 @@
 import { useState, type KeyboardEvent } from "react";
-import React from "react";
 import { X } from "lucide-react";
 import { Box, HStack } from "@chakra-ui/react";
 

--- a/dashboard/src/hooks/useConfig.ts
+++ b/dashboard/src/hooks/useConfig.ts
@@ -5,7 +5,6 @@ import {
   useEffect,
   useCallback,
   useRef,
-  type ReactNode,
 } from "react";
 import { useBackend } from "../console/BackendContext";
 import { showSaveToast, showSaveErrorToast } from "../components/SaveToast";

--- a/dashboard/src/pages/Auth.test.tsx
+++ b/dashboard/src/pages/Auth.test.tsx
@@ -18,21 +18,19 @@ vi.mock("../api/client", async (importOriginal) => {
   };
 });
 
-const makeConfig = (authEnabled: boolean): Config => ({
+const makeConfig = (): Config => ({
   version: 1,
   project: { name: "Test", description: "" },
   tables: {},
-  auth: authEnabled
-    ? {
-        jwt_expiry: "15m",
-        refresh_token_expiry: "7d",
-        allow_signup: null,
-        allow_anonymous: null,
-        redirect_urls: [],
-        email: { verify_email: false, templates: {} },
-        oauth: {},
-      }
-    : null,
+  auth: {
+    jwt_expiry: "15m",
+    refresh_token_expiry: "7d",
+    allow_signup: null,
+    allow_anonymous: null,
+    redirect_urls: [],
+    email: { verify_email: false, templates: {} },
+    oauth: {},
+  },
   storage: {},
   rpc: {},
   functions: {},
@@ -82,39 +80,31 @@ describe("AuthPage", () => {
     vi.mocked(api.getEnvVars).mockResolvedValue({ vars: {} });
   });
 
-  it("shows JWT settings when auth is enabled", () => {
-    renderAuth(makeConfig(true));
+  it("always shows JWT settings — auth is always on, no enable toggle", () => {
+    renderAuth(makeConfig());
     expect(screen.getByText("JWT Settings")).toBeInTheDocument();
     expect(screen.getByDisplayValue("15m")).toBeInTheDocument();
     expect(screen.getByDisplayValue("7d")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Enable authentication")).not.toBeInTheDocument();
+    expect(screen.queryByText("Auth is disabled")).not.toBeInTheDocument();
   });
 
-  it("shows disabled state when auth is off", () => {
-    renderAuth(makeConfig(false));
-    expect(screen.getByText("Auth is disabled")).toBeInTheDocument();
-    expect(screen.queryByText("JWT Settings")).not.toBeInTheDocument();
+  it("materializes defaults when config.auth is null", () => {
+    const config = makeConfig();
+    config.auth = null;
+    renderAuth(config);
+    expect(screen.getByText("JWT Settings")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("15m")).toBeInTheDocument();
   });
 
   it("shows OAuth provider toggles", () => {
-    renderAuth(makeConfig(true));
+    renderAuth(makeConfig());
     expect(screen.getByText("google")).toBeInTheDocument();
     expect(screen.getByText("github")).toBeInTheDocument();
   });
 
-  it("toggles auth on when clicking the toggle", async () => {
-    renderAuth(makeConfig(false));
-    expect(screen.getByText("Auth is disabled")).toBeInTheDocument();
-
-    const toggles = screen.getAllByRole("switch");
-    const authToggle = toggles[0]!;
-    await userEvent.click(authToggle);
-
-    expect(screen.getByText("JWT Settings")).toBeInTheDocument();
-    expect(screen.queryByText("Auth is disabled")).not.toBeInTheDocument();
-  });
-
   it("shows email verification in the combined sign-up section", () => {
-    renderAuth(makeConfig(true));
+    renderAuth(makeConfig());
     expect(screen.getByText("Sign-up & verification")).toBeInTheDocument();
     expect(screen.getByText("Require email verification")).toBeInTheDocument();
   });
@@ -145,7 +135,7 @@ describe("AuthPage", () => {
   });
 
   it("requests status for credential vars, even ones not yet saved in config", () => {
-    renderAuth(makeConfig(true));
+    renderAuth(makeConfig());
     expect(api.getEnvVars).toHaveBeenCalledWith(
       expect.arrayContaining([
         "INSTANCEZ_ENV_GOOGLE_CLIENT_SECRET",
@@ -155,7 +145,7 @@ describe("AuthPage", () => {
   });
 
   it("requests status for ${VAR} refs found in saved OAuth settings", () => {
-    const config = makeConfig(true);
+    const config = makeConfig();
     config.auth!.oauth.google = {
       client_id: "${MY_CUSTOM_CLIENT_ID}",
       client_secret: "${INSTANCEZ_ENV_GOOGLE_CLIENT_SECRET}",
@@ -167,7 +157,7 @@ describe("AuthPage", () => {
   });
 
   it("renders literal OAuth settings as plain editable inputs, creds first", () => {
-    const config = makeConfig(true);
+    const config = makeConfig();
     config.auth!.oauth.google = {
       client_id: "abc123",
       client_secret: "${INSTANCEZ_ENV_GOOGLE_CLIENT_SECRET}",
@@ -189,7 +179,7 @@ describe("AuthPage", () => {
   });
 
   it("shows all three email template editors with default-subject placeholders", () => {
-    renderAuth(makeConfig(true));
+    renderAuth(makeConfig());
     expect(screen.getByText("Verification")).toBeInTheDocument();
     expect(screen.getByText("Magic link")).toBeInTheDocument();
     expect(screen.getByText("Password reset")).toBeInTheDocument();
@@ -199,7 +189,7 @@ describe("AuthPage", () => {
   });
 
   it("reads template overrides from the backend's template keys", () => {
-    const config = makeConfig(true);
+    const config = makeConfig();
     config.auth!.email = {
       verify_email: true,
       templates: {
@@ -211,7 +201,7 @@ describe("AuthPage", () => {
   });
 
   it("hides the save bar again when an edit is undone", () => {
-    const config = makeConfig(true);
+    const config = makeConfig();
     config.auth!.oauth.google = {
       client_id: "abc123",
       client_secret: "${INSTANCEZ_ENV_GOOGLE_CLIENT_SECRET}",
@@ -225,7 +215,7 @@ describe("AuthPage", () => {
   });
 
   it("enabling a provider stages the secret as ${VAR} and settings as literals", async () => {
-    renderAuth(makeConfig(true));
+    renderAuth(makeConfig());
     await userEvent.click(screen.getByRole("switch", { name: /enable google/i }));
     expect(screen.getByText("INSTANCEZ_ENV_GOOGLE_CLIENT_SECRET")).toBeInTheDocument();
     expect(screen.getByLabelText("Client ID")).toHaveValue("");
@@ -237,7 +227,7 @@ describe("AuthPage", () => {
   // a top-level auth.google. Writing the flat key gets rejected as an unknown
   // key by the engine's strict config decode.
   it("saves an enabled provider under auth.oauth, not as a top-level key", async () => {
-    const { save } = renderAuth(makeConfig(true));
+    const { save } = renderAuth(makeConfig());
     await userEvent.click(screen.getByRole("switch", { name: /enable google/i }));
     await userEvent.click(screen.getByRole("button", { name: /save changes/i }));
     const saved = save.mock.calls[0]![0].auth;
@@ -253,7 +243,7 @@ describe("AuthPage", () => {
   // Disabling drops the key entirely rather than leaving `google: null`, so the
   // emitted YAML carries no dead provider entry.
   it("removes the provider key from auth.oauth when disabled", async () => {
-    const config = makeConfig(true);
+    const config = makeConfig();
     config.auth!.oauth.google = {
       client_id: "abc123",
       client_secret: "${INSTANCEZ_ENV_GOOGLE_CLIENT_SECRET}",
@@ -265,7 +255,7 @@ describe("AuthPage", () => {
   });
 
   it("shows Google OAuth var names when Google is enabled", async () => {
-    const config = makeConfig(true);
+    const config = makeConfig();
     config.auth!.oauth.google = {
       client_id: "${INSTANCEZ_GOOGLE_CLIENT_ID}",
       client_secret: "${INSTANCEZ_ENV_GOOGLE_CLIENT_SECRET}",
@@ -279,7 +269,7 @@ describe("AuthPage", () => {
     vi.mocked(api.getEnvVars).mockResolvedValue({
       vars: { INSTANCEZ_GOOGLE_CLIENT_ID: { set: true, tail: "wxyz" } },
     });
-    const config = makeConfig(true);
+    const config = makeConfig();
     config.auth!.oauth.google = {
       client_id: "${INSTANCEZ_GOOGLE_CLIENT_ID}",
       client_secret: "${INSTANCEZ_ENV_GOOGLE_CLIENT_SECRET}",
@@ -289,7 +279,7 @@ describe("AuthPage", () => {
   });
 
   it("shows dotenv input when dotenvWritable=true and provider is enabled", () => {
-    const config = makeConfig(true);
+    const config = makeConfig();
     config.auth!.oauth.google = {
       client_id: "${INSTANCEZ_GOOGLE_CLIENT_ID}",
       client_secret: "${INSTANCEZ_ENV_GOOGLE_CLIENT_SECRET}",
@@ -304,7 +294,7 @@ describe("AuthPage", () => {
   });
 
   it("shows friendly field labels for OAuth config rows", () => {
-    const config = makeConfig(true);
+    const config = makeConfig();
     config.auth!.oauth.google = {
       client_id: "${INSTANCEZ_GOOGLE_CLIENT_ID}",
       client_secret: "${INSTANCEZ_ENV_GOOGLE_CLIENT_SECRET}",
@@ -316,7 +306,7 @@ describe("AuthPage", () => {
   });
 
   it("hides dotenv inputs when dotenvWritable=false", () => {
-    const config = makeConfig(true);
+    const config = makeConfig();
     config.auth!.oauth.google = {
       client_id: "${INSTANCEZ_GOOGLE_CLIENT_ID}",
       client_secret: "${INSTANCEZ_ENV_GOOGLE_CLIENT_SECRET}",
@@ -328,28 +318,28 @@ describe("AuthPage", () => {
   // ---------- Registration (allow_signup / allow_anonymous) ----------
 
   it("shows registration toggles, both on when the flags are unset", () => {
-    renderAuth(makeConfig(true));
+    renderAuth(makeConfig());
     expect(screen.getByText("Sign-up & verification")).toBeInTheDocument();
     expect(screen.getByRole("switch", { name: "Allow public sign-up" })).toBeChecked();
     expect(screen.getByRole("switch", { name: "Allow anonymous sign-in" })).toBeChecked();
   });
 
   it("reflects allow_signup=false as the sign-up toggle being off", () => {
-    const config = makeConfig(true);
+    const config = makeConfig();
     config.auth!.allow_signup = false;
     renderAuth(config);
     expect(screen.getByRole("switch", { name: "Allow public sign-up" })).not.toBeChecked();
   });
 
   it("disables the anonymous toggle when sign-up is off", () => {
-    const config = makeConfig(true);
+    const config = makeConfig();
     config.auth!.allow_signup = false;
     renderAuth(config);
     expect(screen.getByRole("switch", { name: "Allow anonymous sign-in" })).toBeDisabled();
   });
 
   it("writes an explicit boolean when sign-up is toggled off", async () => {
-    const { save } = renderAuth(makeConfig(true));
+    const { save } = renderAuth(makeConfig());
     await userEvent.click(screen.getByRole("switch", { name: "Allow public sign-up" }));
     await userEvent.click(screen.getByRole("button", { name: /save changes/i }));
     expect(save).toHaveBeenCalled();
@@ -359,28 +349,28 @@ describe("AuthPage", () => {
   // ---------- Redirect URLs ----------
 
   it("lists configured redirect URLs", () => {
-    const config = makeConfig(true);
+    const config = makeConfig();
     config.auth!.redirect_urls = ["https://app.example.com"];
     renderAuth(config);
     expect(screen.getByDisplayValue("https://app.example.com")).toBeInTheDocument();
   });
 
   it("flags an invalid redirect origin", () => {
-    const config = makeConfig(true);
+    const config = makeConfig();
     config.auth!.redirect_urls = ["app.example.com"];
     renderAuth(config);
     expect(screen.getByText(/absolute http\(s\) origin/i)).toBeInTheDocument();
   });
 
   it("adds an empty redirect URL row when clicking add", async () => {
-    renderAuth(makeConfig(true));
+    renderAuth(makeConfig());
     expect(screen.queryByLabelText("Redirect URL 1")).not.toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: /add redirect url/i }));
     expect(screen.getByLabelText("Redirect URL 1")).toBeInTheDocument();
   });
 
   it("saves a typed redirect URL into the payload", async () => {
-    const { save } = renderAuth(makeConfig(true));
+    const { save } = renderAuth(makeConfig());
     await userEvent.click(screen.getByRole("button", { name: /add redirect url/i }));
     await userEvent.type(screen.getByLabelText("Redirect URL 1"), "https://app.example.com");
     await userEvent.click(screen.getByRole("button", { name: /save changes/i }));
@@ -388,7 +378,7 @@ describe("AuthPage", () => {
   });
 
   it("removes a redirect URL from the payload", async () => {
-    const config = makeConfig(true);
+    const config = makeConfig();
     config.auth!.redirect_urls = ["https://a.example.com", "https://b.example.com"];
     const { save } = renderAuth(config);
     await userEvent.click(screen.getByRole("button", { name: "Remove redirect URL 1" }));
@@ -397,7 +387,7 @@ describe("AuthPage", () => {
   });
 
   it("drops blank redirect URL rows on save", async () => {
-    const config = makeConfig(true);
+    const config = makeConfig();
     config.auth!.redirect_urls = ["https://app.example.com"];
     const { save } = renderAuth(config);
     // Add a second, empty row, then save without filling it.
@@ -409,7 +399,7 @@ describe("AuthPage", () => {
   // ---------- Round-trip preservation ----------
 
   it("preserves allow_signup/allow_anonymous/redirect_urls across an unrelated edit", async () => {
-    const config = makeConfig(true);
+    const config = makeConfig();
     config.auth!.allow_signup = false;
     config.auth!.allow_anonymous = false;
     config.auth!.redirect_urls = ["https://app.example.com"];

--- a/dashboard/src/pages/Auth.tsx
+++ b/dashboard/src/pages/Auth.tsx
@@ -175,7 +175,7 @@ export function AuthPage() {
     // in the YAML as empty list items.
     const cleanedAuth = {
       ...auth,
-      redirect_urls: (auth.redirect_urls ?? []).map((u) => u.trim()).filter(Boolean),
+      redirect_urls: auth.redirect_urls.map((u) => u.trim()).filter(Boolean),
     };
     const updated = { ...config, auth: cleanedAuth };
     const staged = Object.entries(pendingDotenv).filter(([, v]) => v !== "");

--- a/dashboard/src/pages/Auth.tsx
+++ b/dashboard/src/pages/Auth.tsx
@@ -1,10 +1,9 @@
 import { useState, useEffect, useCallback } from "react";
-import { Shield, KeySquare, Mails, Plug2, UserPlus, Link2, Plus, X } from "lucide-react";
+import { KeySquare, Mails, Plug2, UserPlus, Link2, Plus, X } from "lucide-react";
 import { Box, Grid, HStack, IconButton, Text, VStack } from "@chakra-ui/react";
 import { useConfig } from "../hooks/useConfig";
 import { SaveBar } from "../components/SaveBar";
 import { CodeEditor } from "../components/CodeEditor";
-import { EmptyState } from "../components/EmptyState";
 import { Toggle } from "../components/Toggle";
 import { Field, Input, Panel, Section } from "../components/ui";
 import { VarRow } from "../components/VarRow";
@@ -136,7 +135,6 @@ export function AuthPage() {
   const canWriteSecrets = backend.capabilities.canWriteSecrets && dotenvWritable;
   const showEnvName = backend.capabilities.showsEnvVarNames;
   const [auth, setAuth] = useState<Auth | null>(null);
-  const [enabled, setEnabled] = useState(false);
   const [envVarStatus, setEnvVarStatus] = useState<Record<string, { set: boolean; tail?: string }>>({});
   const [pendingDotenv, setPendingDotenv] = useState<Record<string, string>>({});
 
@@ -154,8 +152,7 @@ export function AuthPage() {
 
   useEffect(() => {
     if (config) {
-      setAuth(config.auth ? structuredClone(config.auth) : null);
-      setEnabled(!!config.auth);
+      setAuth(structuredClone(config.auth ?? DEFAULT_AUTH));
     }
   }, [config]);
 
@@ -173,12 +170,13 @@ export function AuthPage() {
 
   async function handleSave() {
     if (!config) return;
+    if (!auth) return;
     // Drop blank redirect rows (an added-but-unfilled entry) so they don't land
     // in the YAML as empty list items.
-    const cleanedAuth =
-      enabled && auth
-        ? { ...auth, redirect_urls: (auth.redirect_urls ?? []).map((u) => u.trim()).filter(Boolean) }
-        : null;
+    const cleanedAuth = {
+      ...auth,
+      redirect_urls: (auth.redirect_urls ?? []).map((u) => u.trim()).filter(Boolean),
+    };
     const updated = { ...config, auth: cleanedAuth };
     const staged = Object.entries(pendingDotenv).filter(([, v]) => v !== "");
     const ok = await save(updated, {
@@ -211,14 +209,6 @@ export function AuthPage() {
         await loadEnvVars();
       }
     }
-  }
-
-  function toggleAuth() {
-    setEnabled((prev) => {
-      const next = !prev;
-      if (next && !auth) setAuth(structuredClone(DEFAULT_AUTH));
-      return next;
-    });
   }
 
   function toggleOAuth(provider: "google" | "github", isEnabled: boolean) {
@@ -283,32 +273,13 @@ export function AuthPage() {
 
   // Dirty is derived, not a sticky flag: undoing an edit hides the save bar.
   const dirty =
-    !jsonEqual(enabled ? auth : null, config.auth ?? null) ||
+    !jsonEqual(auth, config.auth ?? DEFAULT_AUTH) ||
     Object.values(pendingDotenv).some((v) => v !== "");
 
   return (
     <Box pb="20">
       <VStack pb="8" gap="6" maxW="3xl" align="stretch">
-        {/* Enable/Disable Toggle */}
-        <Section
-          title="Enable Authentication"
-          icon={Shield}
-          actions={
-            <Toggle
-              aria-label="Enable authentication"
-              checked={enabled}
-              onChange={toggleAuth}
-            />
-          }
-        />
-
-        {!enabled ? (
-          <EmptyState
-            icon={Shield}
-            title="Auth is disabled"
-            description="Enable authentication to configure providers and JWT settings."
-          />
-        ) : auth ? (
+        {auth && (
           <>
             <Section
               title="JWT Settings"
@@ -610,7 +581,7 @@ export function AuthPage() {
               })}
             </Section>
           </>
-        ) : null}
+        )}
       </VStack>
 
       {canWriteConfig && (

--- a/dashboard/src/pages/Overview.tsx
+++ b/dashboard/src/pages/Overview.tsx
@@ -55,7 +55,6 @@ export function Overview() {
   const bucketCount = Object.keys(config.storage || {}).length;
   const funcCount = Object.keys(config.functions || {}).length;
   const rpcCount = Object.keys(config.rpc || {}).length;
-  const authEnabled = !!config.auth;
   const exampleTable = Object.keys(config.tables || {}).sort()[0] ?? "todos";
 
   const totalStorage = stats
@@ -143,17 +142,15 @@ export function Overview() {
               <CardTitle>Auth</CardTitle>
               <Box as={Shield} boxSize="4.5" color="fg.muted" />
             </HStack>
-            <CardValue>{authEnabled ? "Enabled" : "Off"}</CardValue>
+            <CardValue>Enabled</CardValue>
             <Text mt="1" fontSize="xs" color="fg.muted">
-              {authEnabled
-                ? [
-                    config.auth?.email ? "Email" : null,
-                    config.auth?.oauth?.google ? "Google" : null,
-                    config.auth?.oauth?.github ? "GitHub" : null,
-                  ]
-                    .filter(Boolean)
-                    .join(", ") || "No providers"
-                : "Not configured"}
+              {[
+                config.auth?.email ? "Email" : null,
+                config.auth?.oauth?.google ? "Google" : null,
+                config.auth?.oauth?.github ? "GitHub" : null,
+              ]
+                .filter(Boolean)
+                .join(", ") || "No providers"}
             </Text>
           </Card>
 

--- a/dashboard/src/pages/SqlEditor.test.tsx
+++ b/dashboard/src/pages/SqlEditor.test.tsx
@@ -39,8 +39,8 @@ describe("SqlEditor", () => {
   it("runs on Cmd/Ctrl+Enter", async () => {
     const runQuery = vi.fn(async () => ({ columns: ["n"], rows: [[1]], row_count: 1 }));
     const { container } = renderPage(mk(runQuery));
-    const content = container.querySelector(".cm-content") as HTMLElement;
-    fireEvent.keyDown(content, { key: "Enter", ctrlKey: true });
+    const editorEl = container.querySelector(".cm-content") as HTMLElement;
+    fireEvent.keyDown(editorEl, { key: "Enter", ctrlKey: true });
     await waitFor(() => expect(runQuery).toHaveBeenCalled());
   });
 });

--- a/dashboard/src/pages/SqlEditor.test.tsx
+++ b/dashboard/src/pages/SqlEditor.test.tsx
@@ -31,4 +31,12 @@ describe("SqlEditor", () => {
     fireEvent.click(screen.getByRole("button", { name: /run/i }));
     expect(await screen.findByText(/permission denied/i)).toBeInTheDocument();
   });
+
+  it("runs on Cmd/Ctrl+Enter", async () => {
+    const runQuery = vi.fn(async () => ({ columns: ["n"], rows: [[1]], row_count: 1 }));
+    const { container } = renderPage(mk(runQuery));
+    const content = container.querySelector(".cm-content")!;
+    fireEvent.keyDown(content, { key: "Enter", ctrlKey: true });
+    await waitFor(() => expect(runQuery).toHaveBeenCalled());
+  });
 });

--- a/dashboard/src/pages/SqlEditor.test.tsx
+++ b/dashboard/src/pages/SqlEditor.test.tsx
@@ -7,7 +7,11 @@ import { fullCapabilities, type ConsoleBackend } from "../console/backend";
 import { SqlEditor } from "./SqlEditor";
 
 function mk(runQuery: ConsoleBackend["runQuery"]) {
-  return { capabilities: fullCapabilities(), runQuery } as unknown as ConsoleBackend;
+  return {
+    capabilities: fullCapabilities(),
+    runQuery,
+    getConfig: async () => ({ tables: {} }),
+  } as unknown as ConsoleBackend;
 }
 function renderPage(b: ConsoleBackend) {
   return renderWithChakra(
@@ -35,7 +39,7 @@ describe("SqlEditor", () => {
   it("runs on Cmd/Ctrl+Enter", async () => {
     const runQuery = vi.fn(async () => ({ columns: ["n"], rows: [[1]], row_count: 1 }));
     const { container } = renderPage(mk(runQuery));
-    const content = container.querySelector(".cm-content")!;
+    const content = container.querySelector(".cm-content") as HTMLElement;
     fireEvent.keyDown(content, { key: "Enter", ctrlKey: true });
     await waitFor(() => expect(runQuery).toHaveBeenCalled());
   });

--- a/dashboard/src/pages/SqlEditor.tsx
+++ b/dashboard/src/pages/SqlEditor.tsx
@@ -27,13 +27,14 @@ export function SqlEditor() {
   const [schema, setSchema] = useState<Record<string, string[]>>();
 
   useEffect(() => {
-    Promise.resolve(backend.getConfig?.())
+    backend
+      .getConfig()
       .then((cfg) => {
-        if (!cfg) return;
-        const map: Record<string, string[]> = {};
-        for (const [name, table] of Object.entries(cfg.tables ?? {}))
-          map[name] = (table.fields ?? []).map((f) => f.name);
-        setSchema(map);
+        setSchema(
+          Object.fromEntries(
+            Object.entries(cfg.tables).map(([name, table]) => [name, table.fields.map((f) => f.name)])
+          )
+        );
       })
       .catch(() => {}); // autocomplete is a nicety; a failed load just means keywords only
   }, [backend]);
@@ -58,7 +59,7 @@ export function SqlEditor() {
         <Button size="sm" onClick={run} disabled={running}><Play size={13} /> Run</Button>
         <Text fontSize="xs" color="fg.subtle" fontFamily="mono">⌘↵</Text>
       </HStack>
-      <Box borderBottomWidth="1px" borderColor="border"><CodeEditor language="sql" value={sql} onChange={setSql} onSubmit={run} sqlSchema={schema} minHeight="220px" /></Box>
+      <Box borderBottomWidth="1px" borderColor="border"><CodeEditor language="sql" value={sql} onChange={setSql} onSubmit={() => void run()} sqlSchema={schema} minHeight="220px" /></Box>
       {error && <Box px="3" py="3"><Text fontSize="sm" color="fg.error" fontFamily="mono" whiteSpace="pre-wrap">{error}</Text></Box>}
       {result && (
         <>

--- a/dashboard/src/pages/SqlEditor.tsx
+++ b/dashboard/src/pages/SqlEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Box, HStack, VStack, Text } from "@chakra-ui/react";
 import { Play, Download } from "lucide-react";
 import { CodeEditor } from "../components/CodeEditor";
@@ -24,6 +24,19 @@ export function SqlEditor() {
   const [result, setResult] = useState<SqlResult | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [running, setRunning] = useState(false);
+  const [schema, setSchema] = useState<Record<string, string[]>>();
+
+  useEffect(() => {
+    Promise.resolve(backend.getConfig?.())
+      .then((cfg) => {
+        if (!cfg) return;
+        const map: Record<string, string[]> = {};
+        for (const [name, table] of Object.entries(cfg.tables ?? {}))
+          map[name] = (table.fields ?? []).map((f) => f.name);
+        setSchema(map);
+      })
+      .catch(() => {}); // autocomplete is a nicety; a failed load just means keywords only
+  }, [backend]);
 
   const run = useCallback(async () => {
     if (!sql.trim() || running) return;
@@ -45,7 +58,7 @@ export function SqlEditor() {
         <Button size="sm" onClick={run} disabled={running}><Play size={13} /> Run</Button>
         <Text fontSize="xs" color="fg.subtle" fontFamily="mono">⌘↵</Text>
       </HStack>
-      <Box borderBottomWidth="1px" borderColor="border"><CodeEditor language="sql" value={sql} onChange={setSql} minHeight="220px" /></Box>
+      <Box borderBottomWidth="1px" borderColor="border"><CodeEditor language="sql" value={sql} onChange={setSql} onSubmit={run} sqlSchema={schema} minHeight="220px" /></Box>
       {error && <Box px="3" py="3"><Text fontSize="sm" color="fg.error" fontFamily="mono" whiteSpace="pre-wrap">{error}</Text></Box>}
       {result && (
         <>

--- a/dashboard/src/pages/Tables.tsx
+++ b/dashboard/src/pages/Tables.tsx
@@ -10,7 +10,7 @@ import { useBackend } from "../console/BackendContext";
 
 export function Tables() {
   const backend = useBackend();
-  const { config, save } = useConfig();
+  const { config } = useConfig();
   const navigate = useNavigate();
   const dialog = useDialog();
   const canWriteConfig = backend.capabilities.canWriteConfig;


### PR DESCRIPTION
## SQL editor fixes (`CodeEditor.tsx`, `SqlEditor.tsx`)

Three bugs in the dashboard SQL editor, all frontend-only. The platform
(`instancez-platform` `web`) consumes this dashboard as `@instancez/console`
and supplies its own `getConfig`/`runQuery`, so both are fixed with no
platform changes.

- **Autocomplete popup unreadable in dark mode** — the completion tooltip had
  no theming, and no `darkTheme` facet is set, so it fell back to CodeMirror's
  light defaults. Now themed via the existing `--c-*`/`--syn-*` CSS vars.
- **Run hotkey (⌘/Ctrl+↵) did nothing** — nothing bound it, and `basicSetup`'s
  `defaultKeymap` maps `Mod-Enter` to insert-blank-line. Added a `Prec.highest`
  keymap → `onSubmit`. It returns `false` when no `onSubmit` is passed, so the
  other five `CodeEditor` instances keep their insert-blank-line behavior.
- **Identifiers not suggested** — `SqlEditor` now loads `getConfig().tables`
  into `sql({ schema })`, so table/column names autocomplete. SQL keywords
  already came from `@codemirror/lang-sql`.

Users page already paginates (50/page), so no change there.

## Auth always-on (`Auth.tsx`, `Overview.tsx`)

Auth defaults to `DEFAULT_AUTH` instead of `null`; removes the enable/disable
toggle and the disabled empty-state. Overview's Auth card reflects it as always
enabled.

## Tests

- `tsc -b` clean; `npm test` green (50 files).
- New: ⌘↵ runs the query; plain Enter does not; ⌘↵ with no `onSubmit` still
  inserts a blank line (regression guard — fails on the pre-fix code).

Not visually asserted: the dark-mode popup colors (jsdom can't check rendered
CSS-var colors); class names are verified.
