### PR TITLE
fix(dashboard): normalize null config collections in useConfigState

### DIFF
--- a/dashboard/src/hooks/useConfig.test.tsx
+++ b/dashboard/src/hooks/useConfig.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent, act, renderHook } from "@testing-library/react";
 import { renderWithChakra } from "../test/helpers";
 import { useConfigState } from "./useConfig";
 import { ConfirmSaveDialog } from "../components/ConfirmSaveDialog";
@@ -208,5 +208,64 @@ describe("useConfigState error toast", () => {
     expect(showSaveErrorToast).toHaveBeenCalledWith(
       expect.objectContaining({ message: "server exploded" })
     );
+  });
+});
+
+// The wire shape a backend sends for an app with nothing configured: nil Go
+// maps/slices marshal to JSON null even though the Config type marks them
+// required. useConfigState must coerce these so tabs don't crash on
+// Object.entries / .map / .length.
+const nullConfig = {
+  version: 1,
+  project: { name: "P", description: "" },
+  providers: { email: null, storage: null },
+  auth: {
+    jwt_expiry: "1h",
+    refresh_token_expiry: "24h",
+    allow_signup: null,
+    allow_anonymous: null,
+    redirect_urls: null,
+    email: { verify_email: false, templates: null },
+    oauth: null,
+  },
+  tables: { todos: { fields: null, indexes: null, rls: null } },
+  storage: null,
+  rpc: { ping: { args: null } },
+  functions: null,
+  _checksum: "c1",
+} as unknown as Config;
+
+describe("useConfigState null-collection normalization", () => {
+  it("coerces null maps/slices to empty at every level on the seeded path", () => {
+    const { result } = renderHook(() => useConfigState(nullConfig));
+    const cfg = result.current.config;
+    expect(cfg?.storage).toEqual({});
+    expect(cfg?.functions).toEqual({});
+    expect(cfg?.tables.todos?.fields).toEqual([]);
+    expect(cfg?.tables.todos?.indexes).toEqual([]);
+    expect(cfg?.tables.todos?.rls).toEqual([]);
+    expect(cfg?.rpc.ping?.args).toEqual([]);
+    expect(cfg?.auth?.redirect_urls).toEqual([]);
+    expect(cfg?.auth?.oauth).toEqual({});
+    expect(cfg?.auth?.email?.templates).toEqual({});
+  });
+
+  it("preserves genuinely-nullable fields", () => {
+    const { result } = renderHook(() => useConfigState(nullConfig));
+    expect(result.current.config?.providers.email).toBeNull();
+    expect(result.current.config?.providers.storage).toBeNull();
+  });
+
+  it("leaves auth null when the whole block is null", () => {
+    const { result } = renderHook(() => useConfigState({ ...nullConfig, auth: null } as Config));
+    expect(result.current.config?.auth).toBeNull();
+  });
+
+  it("normalizes the fetched config on the unseeded (refresh) path", async () => {
+    vi.mocked(api.getConfig).mockResolvedValue(nullConfig);
+    const { result } = renderHook(() => useConfigState());
+    await waitFor(() => expect(result.current.config).not.toBeNull());
+    expect(result.current.config?.storage).toEqual({});
+    expect(result.current.config?.tables.todos?.fields).toEqual([]);
   });
 });

--- a/dashboard/src/hooks/useConfig.ts
+++ b/dashboard/src/hooks/useConfig.ts
@@ -51,6 +51,47 @@ const ConfigContext = createContext<ConfigState | null>(null);
 
 export { ConfigContext };
 
+// Both backends (engine + platform) serialize empty Go maps/slices as JSON
+// null, but the Config type marks these collections required and every tab
+// iterates them directly (Object.entries / .map / .length). Coerce null → the
+// empty collection at this single seam — the one place both the OSS refresh and
+// the platform-seeded config converge — so no tab, current or future, crashes.
+// Genuinely-nullable fields (auth, providers.*, oauth values, foreign_key,
+// min/max) are left untouched.
+// The `?? []`/`?? {}` live in these helpers so the coalesce operand is a
+// genuinely nullable type — the Config type marks the collections non-null
+// (that's the lie we're correcting), so an inline `x.fields ?? []` reads as
+// dead code to the type-aware linter.
+const orArr = <V,>(v: V[] | null | undefined): V[] => v ?? [];
+const orMap = <V,>(m: Record<string, V> | null | undefined): Record<string, V> => m ?? {};
+const mapVals = <V,>(m: Record<string, V> | null | undefined, fn: (v: V) => V): Record<string, V> =>
+  Object.fromEntries(Object.entries(orMap(m)).map(([k, v]) => [k, fn(v)]));
+
+function normalizeConfig<T extends Config | null>(cfg: T): T {
+  if (!cfg) return cfg;
+  const auth = cfg.auth;
+  return {
+    ...cfg,
+    tables: mapVals(cfg.tables, (t) => ({
+      ...t,
+      fields: orArr(t.fields),
+      indexes: orArr(t.indexes),
+      rls: orArr(t.rls),
+    })),
+    storage: mapVals(cfg.storage, (b) => ({ ...b, types: orArr(b.types), rls: orArr(b.rls) })),
+    rpc: mapVals(cfg.rpc, (r) => ({ ...r, args: orArr(r.args) })),
+    functions: orMap(cfg.functions),
+    auth: auth
+      ? {
+          ...auth,
+          redirect_urls: orArr(auth.redirect_urls),
+          oauth: orMap(auth.oauth),
+          email: auth.email ? { ...auth.email, templates: orMap(auth.email.templates) } : auth.email,
+        }
+      : auth,
+  } as T;
+}
+
 export function useConfig(): ConfigState {
   const ctx = useContext(ConfigContext);
   if (!ctx) throw new Error("useConfig must be used within ConfigProvider");
@@ -59,7 +100,7 @@ export function useConfig(): ConfigState {
 
 export function useConfigState(initialConfig?: Config | null): ConfigStateWithDialog {
   const backend = useBackend();
-  const [config, setConfig] = useState<Config | null>(initialConfig ?? null);
+  const [config, setConfig] = useState<Config | null>(normalizeConfig(initialConfig ?? null));
   const [loading, setLoading] = useState(initialConfig == null);
   const [error, setError] = useState<string | null>(null);
   const [checksum, setChecksum] = useState(initialConfig?._checksum ?? "");
@@ -79,7 +120,7 @@ export function useConfigState(initialConfig?: Config | null): ConfigStateWithDi
         backend.getConfigStatus().catch(() => null),
       ]);
       setChecksum(cfg._checksum || "");
-      setConfig(cfg);
+      setConfig(normalizeConfig(cfg));
       setDotenvWritable(status?.dotenv_writable ?? false);
       setOauthCallbackBase(status?.oauth_callback_base ?? "");
     } catch (e: any) {


### PR DESCRIPTION
## Problem
The Storage tab (and others) crashed with `Cannot convert undefined or null to object` for apps with no buckets. Both backends serialize empty Go maps/slices as JSON `null`, but the `Config` type marks these collections required and every tab iterates them directly (`Object.entries` / `.map` / `.length`).

## Fix
Coerce `null` → the empty collection once in `useConfigState` — the single seam where both the platform-seeded config and the OSS `refresh()` converge — so no tab needs its own guard. Covers the whole `Config` type (top-level maps + nested `Table`/`Bucket`/`RpcFunction`/`Auth` collections). Genuinely-nullable fields (`auth`, `providers.*`, `oauth` values) are left untouched.

## Tests
Added 4 normalization tests (seeded + refresh paths, coerce-vs-preserve-null) alongside the existing save-flow suite. Full dashboard suite: 340 passing, typecheck clean.