### PR TITLE
fix(migrate): migrate RPC signature changes and index attribute changes

### DIFF
--- a/internal/app/migrate_config_diff.go
+++ b/internal/app/migrate_config_diff.go
@@ -210,9 +210,14 @@ func diffRemovedIndexes(old, new *domain.Config) []string {
 	return ddl
 }
 
+// hasIndex reports whether an identical index (columns, uniqueness, WHERE)
+// exists; a same-columns index that changed keeps its name, so it must be
+// dropped rather than silently no-op'd by CREATE INDEX IF NOT EXISTS.
 func hasIndex(indexes []domain.Index, target domain.Index) bool {
 	for _, idx := range indexes {
-		if strings.Join(idx.Columns, ",") == strings.Join(target.Columns, ",") {
+		if slices.Equal(idx.Columns, target.Columns) &&
+			idx.Unique == target.Unique &&
+			idx.Where == target.Where {
 			return true
 		}
 	}
@@ -297,18 +302,43 @@ func storageRLSPolicyNames(bucketName string, policies []domain.RLSPolicy) []str
 	return names
 }
 
-// diffRemovedRPCFunctions returns DROP FUNCTION statements for functions
-// that existed in old but are no longer in new.
+// diffRemovedRPCFunctions returns DROP FUNCTION statements for functions removed
+// from new, and for functions whose signature changed. CREATE OR REPLACE can't
+// reconcile a signature change, so the old function is dropped by its old
+// signature first and rebuilt by the idempotent re-emit in planUpdate.
 func diffRemovedRPCFunctions(old, new *domain.Config) []string {
 	var ddl []string
 	for _, name := range sortedKeys(old.RPC) {
-		fn := old.RPC[name]
-		if _, exists := new.RPC[name]; !exists {
-			sig := rpcFunctionDropSig(fn)
-			ddl = append(ddl, fmt.Sprintf("DROP FUNCTION IF EXISTS public.\"%s\"(%s);", name, sig))
+		oldFn := old.RPC[name]
+		newFn, exists := new.RPC[name]
+		if exists && !rpcSignatureChanged(oldFn, newFn) {
+			continue
 		}
+		ddl = append(ddl, fmt.Sprintf("DROP FUNCTION IF EXISTS public.\"%s\"(%s);", name, rpcFunctionDropSig(oldFn)))
 	}
 	return ddl
+}
+
+// rpcSignatureChanged reports whether a change breaks CREATE OR REPLACE: arg
+// count, any arg name or type, the return type, or a removed arg default (types
+// normalized so int/integer don't force a needless recreate).
+func rpcSignatureChanged(old, new domain.Function) bool {
+	if len(old.Args) != len(new.Args) {
+		return true
+	}
+	for i := range old.Args {
+		if old.Args[i].Name != new.Args[i].Name {
+			return true
+		}
+		if domain.Normalize(old.Args[i].Type) != domain.Normalize(new.Args[i].Type) {
+			return true
+		}
+		// Postgres refuses to remove a parameter default via CREATE OR REPLACE.
+		if old.Args[i].Default != nil && new.Args[i].Default == nil {
+			return true
+		}
+	}
+	return domain.Normalize(old.Returns.Type) != domain.Normalize(new.Returns.Type)
 }
 
 // rpcFunctionDropSig builds the argument type list needed for DROP FUNCTION

--- a/internal/app/migrate_config_diff_test.go
+++ b/internal/app/migrate_config_diff_test.go
@@ -778,3 +778,178 @@ func TestDiffConfigs_SelfDiffEmpty(t *testing.T) {
 		t.Fatalf("self-diff produced ALTERs: %v", ddl)
 	}
 }
+
+// --- RPC signature changes (CREATE OR REPLACE can't reconcile these) ---
+
+func rpcOf(fn domain.Function) *domain.Config {
+	return &domain.Config{RPC: map[string]domain.Function{"greet": fn}}
+}
+
+func TestDiffConfigs_RPCReturnTypeChange_DropsOldSignature(t *testing.T) {
+	old := rpcOf(domain.Function{Returns: domain.FuncReturn{Type: "int"}, Body: "SELECT 1", Language: "sql"})
+	new := rpcOf(domain.Function{Returns: domain.FuncReturn{Type: "text"}, Body: "SELECT 'x'", Language: "sql"})
+
+	diff := diffConfigs(old, new)
+	joined := strings.Join(diff.Removals, "\n")
+	mustContain(t, joined, `DROP FUNCTION IF EXISTS public."greet"()`)
+}
+
+func TestDiffConfigs_RPCArgTypeChange_DropsOldSignature(t *testing.T) {
+	old := rpcOf(domain.Function{Args: []domain.FuncArg{{Name: "a", Type: "int"}}, Returns: domain.FuncReturn{Type: "int"}, Body: "SELECT a", Language: "sql"})
+	new := rpcOf(domain.Function{Args: []domain.FuncArg{{Name: "a", Type: "text"}}, Returns: domain.FuncReturn{Type: "int"}, Body: "SELECT length(a)", Language: "sql"})
+
+	diff := diffConfigs(old, new)
+	joined := strings.Join(diff.Removals, "\n")
+	// Drop by the OLD signature: the new CREATE targets a different overload.
+	mustContain(t, joined, `DROP FUNCTION IF EXISTS public."greet"(int)`)
+}
+
+func TestDiffConfigs_RPCArgNameChange_DropsOldSignature(t *testing.T) {
+	old := rpcOf(domain.Function{Args: []domain.FuncArg{{Name: "a", Type: "int"}}, Returns: domain.FuncReturn{Type: "int"}, Body: "SELECT a", Language: "sql"})
+	new := rpcOf(domain.Function{Args: []domain.FuncArg{{Name: "b", Type: "int"}}, Returns: domain.FuncReturn{Type: "int"}, Body: "SELECT b", Language: "sql"})
+
+	diff := diffConfigs(old, new)
+	joined := strings.Join(diff.Removals, "\n")
+	mustContain(t, joined, `DROP FUNCTION IF EXISTS public."greet"(int)`)
+}
+
+func TestDiffConfigs_RPCArgDefaultRemoved_DropsOldSignature(t *testing.T) {
+	five := any(5)
+	old := rpcOf(domain.Function{Args: []domain.FuncArg{{Name: "a", Type: "int", Default: five}}, Returns: domain.FuncReturn{Type: "int"}, Body: "SELECT a", Language: "sql"})
+	new := rpcOf(domain.Function{Args: []domain.FuncArg{{Name: "a", Type: "int"}}, Returns: domain.FuncReturn{Type: "int"}, Body: "SELECT a", Language: "sql"})
+
+	diff := diffConfigs(old, new)
+	joined := strings.Join(diff.Removals, "\n")
+	// Postgres refuses to remove a parameter default via CREATE OR REPLACE.
+	mustContain(t, joined, `DROP FUNCTION IF EXISTS public."greet"(int)`)
+}
+
+func TestDiffConfigs_RPCArgDefaultAdded_NoDrop(t *testing.T) {
+	old := rpcOf(domain.Function{Args: []domain.FuncArg{{Name: "a", Type: "int"}}, Returns: domain.FuncReturn{Type: "int"}, Body: "SELECT a", Language: "sql"})
+	new := rpcOf(domain.Function{Args: []domain.FuncArg{{Name: "a", Type: "int", Default: any(5)}}, Returns: domain.FuncReturn{Type: "int"}, Body: "SELECT a", Language: "sql"})
+
+	diff := diffConfigs(old, new)
+	// Adding a default is accepted by CREATE OR REPLACE, so no drop.
+	if len(diff.Removals) != 0 {
+		t.Errorf("adding an arg default should not drop the function, got: %v", diff.Removals)
+	}
+}
+
+func TestDiffConfigs_RPCArgCountChange_DropsOldSignature(t *testing.T) {
+	old := rpcOf(domain.Function{Args: []domain.FuncArg{{Name: "a", Type: "int"}}, Returns: domain.FuncReturn{Type: "int"}, Body: "SELECT a", Language: "sql"})
+	new := rpcOf(domain.Function{Args: []domain.FuncArg{{Name: "a", Type: "int"}, {Name: "b", Type: "int"}}, Returns: domain.FuncReturn{Type: "int"}, Body: "SELECT a + b", Language: "sql"})
+
+	diff := diffConfigs(old, new)
+	joined := strings.Join(diff.Removals, "\n")
+	mustContain(t, joined, `DROP FUNCTION IF EXISTS public."greet"(int)`)
+}
+
+func TestDiffConfigs_RPCBodyOnlyChange_NoDrop(t *testing.T) {
+	old := rpcOf(domain.Function{Args: []domain.FuncArg{{Name: "a", Type: "int"}}, Returns: domain.FuncReturn{Type: "int"}, Body: "SELECT a", Language: "sql"})
+	new := rpcOf(domain.Function{Args: []domain.FuncArg{{Name: "a", Type: "int"}}, Returns: domain.FuncReturn{Type: "int"}, Body: "SELECT a * 2", Language: "sql"})
+
+	diff := diffConfigs(old, new)
+	// Same signature: CREATE OR REPLACE handles a body change, so no drop.
+	if len(diff.Removals) != 0 {
+		t.Errorf("body-only change should not drop the function, got: %v", diff.Removals)
+	}
+}
+
+func TestDiffConfigs_RPCArgTypeAlias_NoDrop(t *testing.T) {
+	old := rpcOf(domain.Function{Args: []domain.FuncArg{{Name: "a", Type: "int"}}, Returns: domain.FuncReturn{Type: "int"}, Body: "SELECT a", Language: "sql"})
+	new := rpcOf(domain.Function{Args: []domain.FuncArg{{Name: "a", Type: "integer"}}, Returns: domain.FuncReturn{Type: "int"}, Body: "SELECT a", Language: "sql"})
+
+	diff := diffConfigs(old, new)
+	// int and integer normalize to the same Postgres type: no needless drop.
+	if len(diff.Removals) != 0 {
+		t.Errorf("aliased arg type should not drop the function, got: %v", diff.Removals)
+	}
+}
+
+// Full-plan regression: a return-type change must produce DROP FUNCTION before
+// the re-emitted CREATE OR REPLACE, or the migration fails against Postgres.
+func TestPlanUpdate_RPCSignatureChange_DropBeforeCreate(t *testing.T) {
+	old := rpcOf(domain.Function{Returns: domain.FuncReturn{Type: "int"}, Body: "SELECT 1", Language: "sql"})
+	new := rpcOf(domain.Function{Returns: domain.FuncReturn{Type: "text"}, Body: "SELECT 'x'", Language: "sql"})
+
+	stmts := planUpdateStatements(old, new, domain.DefaultRoles())
+	joined := strings.Join(stmts, "\n")
+	dropAt := strings.Index(joined, `DROP FUNCTION IF EXISTS public."greet"`)
+	createAt := strings.Index(joined, `CREATE OR REPLACE FUNCTION public."greet"`)
+	if dropAt < 0 {
+		t.Fatalf("expected DROP FUNCTION in plan:\n%s", joined)
+	}
+	if createAt < 0 {
+		t.Fatalf("expected CREATE OR REPLACE FUNCTION in plan:\n%s", joined)
+	}
+	if dropAt > createAt {
+		t.Errorf("DROP FUNCTION must precede CREATE OR REPLACE, got drop@%d create@%d", dropAt, createAt)
+	}
+}
+
+// --- Index definition changes (same columns, different attributes) ---
+
+func TestDiffConfigs_IndexUniqueFlipped_DropsIndex(t *testing.T) {
+	old := &domain.Config{Tables: map[string]domain.Table{
+		"todos": {Fields: []domain.Field{{Name: "id", Type: "bigserial"}, {Name: "code", Type: "text"}},
+			Indexes: []domain.Index{{Columns: []string{"code"}, Unique: true}}},
+	}}
+	new := &domain.Config{Tables: map[string]domain.Table{
+		"todos": {Fields: []domain.Field{{Name: "id", Type: "bigserial"}, {Name: "code", Type: "text"}},
+			Indexes: []domain.Index{{Columns: []string{"code"}, Unique: false}}},
+	}}
+
+	diff := diffConfigs(old, new)
+	joined := strings.Join(diff.Removals, "\n")
+	mustContain(t, joined, "DROP INDEX IF EXISTS idx_todos_code;")
+}
+
+func TestDiffConfigs_IndexWhereChanged_DropsIndex(t *testing.T) {
+	old := &domain.Config{Tables: map[string]domain.Table{
+		"todos": {Fields: []domain.Field{{Name: "id", Type: "bigserial"}, {Name: "status", Type: "text"}},
+			Indexes: []domain.Index{{Columns: []string{"status"}, Where: "status = 'open'"}}},
+	}}
+	new := &domain.Config{Tables: map[string]domain.Table{
+		"todos": {Fields: []domain.Field{{Name: "id", Type: "bigserial"}, {Name: "status", Type: "text"}},
+			Indexes: []domain.Index{{Columns: []string{"status"}, Where: "status = 'done'"}}},
+	}}
+
+	diff := diffConfigs(old, new)
+	joined := strings.Join(diff.Removals, "\n")
+	mustContain(t, joined, "DROP INDEX IF EXISTS idx_todos_status;")
+}
+
+func TestDiffConfigs_IndexUnchanged_NoDrop(t *testing.T) {
+	cfg := &domain.Config{Tables: map[string]domain.Table{
+		"todos": {Fields: []domain.Field{{Name: "id", Type: "bigserial"}, {Name: "code", Type: "text"}},
+			Indexes: []domain.Index{{Columns: []string{"code"}, Unique: true, Where: "code IS NOT NULL"}}},
+	}}
+	diff := diffConfigs(cfg, cfg)
+	if strings.Contains(strings.Join(diff.Removals, "\n"), "DROP INDEX") {
+		t.Errorf("identical index should not be dropped, got: %v", diff.Removals)
+	}
+}
+
+// Full-plan regression: a changed index must DROP before the re-emitted CREATE,
+// since both share the generated name.
+func TestPlanUpdate_IndexChange_DropBeforeCreate(t *testing.T) {
+	old := &domain.Config{Tables: map[string]domain.Table{
+		"todos": {Fields: []domain.Field{{Name: "id", Type: "bigserial"}, {Name: "code", Type: "text"}},
+			Indexes: []domain.Index{{Columns: []string{"code"}, Unique: true}}},
+	}}
+	new := &domain.Config{Tables: map[string]domain.Table{
+		"todos": {Fields: []domain.Field{{Name: "id", Type: "bigserial"}, {Name: "code", Type: "text"}},
+			Indexes: []domain.Index{{Columns: []string{"code"}, Unique: false}}},
+	}}
+
+	stmts := planUpdateStatements(old, new, domain.DefaultRoles())
+	joined := strings.Join(stmts, "\n")
+	dropAt := strings.Index(joined, "DROP INDEX IF EXISTS idx_todos_code;")
+	createAt := strings.Index(joined, "CREATE INDEX IF NOT EXISTS idx_todos_code")
+	if dropAt < 0 || createAt < 0 {
+		t.Fatalf("expected both DROP and CREATE for idx_todos_code:\n%s", joined)
+	}
+	if dropAt > createAt {
+		t.Errorf("DROP INDEX must precede CREATE INDEX, got drop@%d create@%d", dropAt, createAt)
+	}
+}

--- a/internal/app/migrate_integration_test.go
+++ b/internal/app/migrate_integration_test.go
@@ -473,6 +473,107 @@ func TestIntegration_RPCFunction_CreateAndRemove(t *testing.T) {
 	}
 }
 
+func indexIsUnique(t *testing.T, db *postgres.DB, name string) bool {
+	t.Helper()
+	row, err := db.QueryRow(context.Background(),
+		`SELECT i.indisunique FROM pg_class c JOIN pg_index i ON i.indexrelid = c.oid WHERE c.relname = $1`, name)
+	if err != nil {
+		t.Fatalf("indexIsUnique: %v", err)
+	}
+	return row["indisunique"] == true
+}
+
+// TestIntegration_RPCSignatureChange proves the signature-change fix against a
+// real database. Postgres rejects a return-type change via CREATE OR REPLACE,
+// so without the DROP-first fix the v2 Apply would fail outright.
+func TestIntegration_RPCSignatureChange(t *testing.T) {
+	db := startPostgres(t)
+	ctx := context.Background()
+
+	cfgV1 := &domain.Config{
+		Version: 1,
+		Tables:  map[string]domain.Table{},
+		RPC: map[string]domain.Function{
+			"describe": {
+				Language: "sql", Volatility: "immutable", Security: "invoker",
+				Returns: domain.FuncReturn{Type: "int"},
+				Body:    "SELECT 1;",
+			},
+		},
+	}
+	migrator := app.NewMigrator(db).AllowDestructive(true)
+	if err := migrator.Apply(ctx, cfgV1); err != nil {
+		t.Fatalf("v1 apply: %v", err)
+	}
+
+	// v2: same name, changed return type AND a new argument.
+	cfgV2 := &domain.Config{
+		Version: 1,
+		Tables:  map[string]domain.Table{},
+		RPC: map[string]domain.Function{
+			"describe": {
+				Language: "sql", Volatility: "immutable", Security: "invoker",
+				Returns: domain.FuncReturn{Type: "text"},
+				Args:    []domain.FuncArg{{Name: "n", Type: "int"}},
+				Body:    "SELECT n::text;",
+			},
+		},
+	}
+	if err := migrator.Apply(ctx, cfgV2); err != nil {
+		t.Fatalf("v2 apply (signature change) should succeed after DROP-first fix: %v", err)
+	}
+
+	// The new signature must be callable, and the old zero-arg overload gone.
+	row, err := db.QueryRow(ctx, `SELECT public."describe"(42) AS result`)
+	if err != nil {
+		t.Fatalf("call describe(int): %v", err)
+	}
+	if fmt.Sprint(row["result"]) != "42" {
+		t.Fatalf("expected \"42\", got %v", row["result"])
+	}
+	if _, err := db.QueryRow(ctx, `SELECT public."describe"()`); err == nil {
+		t.Fatal("old zero-arg describe() overload should no longer exist")
+	}
+}
+
+// TestIntegration_IndexAttributeChange proves the index-definition fix. Flipping
+// uniqueness keeps the generated name, so without the DROP the CREATE INDEX
+// IF NOT EXISTS no-ops and the index stays non-unique.
+func TestIntegration_IndexAttributeChange(t *testing.T) {
+	db := startPostgres(t)
+	ctx := context.Background()
+
+	base := func(unique bool) *domain.Config {
+		return &domain.Config{
+			Version: 1,
+			Tables: map[string]domain.Table{
+				"todos": {
+					Fields: []domain.Field{
+						{Name: "id", Type: "bigserial", PrimaryKey: true},
+						{Name: "code", Type: "text"},
+					},
+					Indexes: []domain.Index{{Columns: []string{"code"}, Unique: unique}},
+				},
+			},
+		}
+	}
+
+	migrator := app.NewMigrator(db).AllowDestructive(true)
+	if err := migrator.Apply(ctx, base(false)); err != nil {
+		t.Fatalf("v1 apply: %v", err)
+	}
+	if indexIsUnique(t, db, "idx_todos_code") {
+		t.Fatal("index should be non-unique after v1")
+	}
+
+	if err := migrator.Apply(ctx, base(true)); err != nil {
+		t.Fatalf("v2 apply: %v", err)
+	}
+	if !indexIsUnique(t, db, "idx_todos_code") {
+		t.Fatal("index should be unique after v2 (drop + recreate)")
+	}
+}
+
 func TestIntegration_ConfigStoredAndRecovered(t *testing.T) {
 	db := startPostgres(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Problem

Two migration-diff bugs, both on the **change** path (add/remove already worked):

1. **RPC functions** — `planUpdate` re-emits every function as `CREATE OR REPLACE`, but only *removed* functions were dropped. Postgres refuses `CREATE OR REPLACE` that changes a function's **return type** or **parameter names**, refuses to **remove a parameter default**, and an **argument-type** change resolves as a *new* overload that strands the old one. So changing a function's shape failed the migration or left a ghost function behind. (Body-only edits always worked — which is why it looked like RPC "sometimes" migrated.)

2. **Indexes** — `hasIndex` compared **columns only**. Flipping `unique`/`where` on the same columns kept the generated index name, so the idempotent `CREATE INDEX IF NOT EXISTS` no-op'd and the change was silently discarded. (A fully-removed index *was* dropped correctly.)

## Fix

- `hasIndex` now compares the full index definition (columns + `unique` + `where`); a changed index is treated as removed → `DROP INDEX` runs before the idempotent re-`CREATE` (removals precede re-emit in `planUpdate`).
- `diffRemovedRPCFunctions` also drops functions whose **signature changed** (`rpcSignatureChanged`: arg count / name / type, return type, or a removed arg default — each verified against Postgres to break `CREATE OR REPLACE`), dropped by the *old* signature so the re-emit rebuilds cleanly. Adding or changing a default value is left to `CREATE OR REPLACE` (no needless drop); type aliases (`int`/`integer`) are normalized.

## Tests

- **Unit** (`migrate_config_diff_test.go`): return/arg-type/arg-name/arg-count/default-removed changes drop; body-only, type-alias, and default-added do not; index unique/where changes drop, identical do not; plan-level ordering asserts DROP precedes CREATE for both.
- **Integration** (real Postgres): `TestIntegration_RPCSignatureChange` (return-type change + new arg — errored before the fix) and `TestIntegration_IndexAttributeChange` (uniqueness actually flips, checked via `pg_index.indisunique`).

Verified locally: `go build ./...`, `go test -race ./internal/app/`, and `go test -tags=integration -race ./internal/app/` all green.

## Known remaining gaps (out of scope, not introduced here)

- Generated index name `idx_<table>_<cols>` ignores unique/where, so two index entries on the *same columns* differing only in unique/where collide on name (pre-existing).
- Constraint changes (enum/check/min/max/unique) on **existing** columns are not diffed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)